### PR TITLE
meta description

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -20,7 +20,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>MDN Web Docs</title>
-    <meta name="description" content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps. It also has some developer-oriented documentation for Mozilla products, such as Firefox Developer Tools.">
+    <meta name="description" content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps.">
   </head>
   <body>
     <!-- <noscript>You need to enable JavaScript to run this app.</noscript> -->

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -20,6 +20,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>MDN Web Docs</title>
+    <meta name="description" content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps. It also has some developer-oriented documentation for Mozilla products, such as Firefox Developer Tools.">
   </head>
   <body>
     <!-- <noscript>You need to enable JavaScript to run this app.</noscript> -->


### PR DESCRIPTION
Lighthouse complained about this:
<img width="1019" alt="Screen Shot 2019-06-27 at 11 21 40 AM" src="https://user-images.githubusercontent.com/26739/60278613-c3128800-98cd-11e9-8cb0-6c5f0b234b18.png">

I just copied it verbatim from developer.mozilla.org