### PR TITLE
stumptown-content can be anywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-STUMPTOWN_CONTENT_ROOT ?= ../stumptown
-
 clean:
 	rm -fr .make.built .make.installed
 
@@ -14,7 +12,7 @@ build:
 	ls .make.installed || make install
 	cd stumptown && npm run build-json html && cd -
 	cd client && yarn run build && cd -
-	cd cli && yarn run run "${STUMPTOWN_CONTENT_ROOT}/packaged/" && cd -
+	cd cli && yarn run run && cd -
 	touch .make.built
 
 run-server:
@@ -33,7 +31,7 @@ deployment-build:
 build-content:
 	ls .make.built || make build
 	cd stumptown && npm run build-json html && cd -
-	cd cli && yarn run run "${STUMPTOWN_CONTENT_ROOT}/packaged/" && cd -
+	cd cli && yarn run run && cd -
 
 yarn-audit-all:
 	ls .make.installed || make install

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ can be shipped to a static hosting platform like AWS S3 for example.
 
 If you're actively working on a piece of content in `stumptown-content` but
 for convenience you don't want to mess with the `stumptown-content` that
-is available here in this project as a git submodule (named `stumptown`),
+is available here in this project as a *git submodule* (named `stumptown`),
 then you can set the `STUMPTOWN_CONTENT_ROOT` environment variable.
 For example:
 


### PR DESCRIPTION
Fixes #76

This, I hope, greatly simplifies things. Now the `cli` works so that if no special file or folder is specified, it just defaults to `../stumptown/packaged`. 

This...
```
cd cli
yarn run run
```
...is exactly the same as...
```
cd cli
yarn run run ../stumptown/packaged
```

But you can always ignore the defaults and control it entirely manually like this:
```
cd cli
yarn run run ~/stumptown-content/packaged/html/reference/elements/dialog.json
# or 
yarn run run ~/stumptown-content/packaged/html/reference/elements/
```

By default, the root of the content is `../stumptown` and that's what `$STUMPTOWN_CONTENT_ROOT` becomes if you don't set the env var. 


This...
```
cd cli
STUMPTOWN_CONTENT_ROOT=/path/to/stumptown-content yarn run run
```
...is exactly the same as...
```
cd cli
yarn run run /path/to/stumptown-content/packaged
```

