### PR TITLE
flatten 'additional_prose'

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -53,6 +53,10 @@ function fixRelatedContentURIs(document) {
 /** Flatten 'additional_prose' sections.
  * Basically if the document.body has any sections called 'additional_prose'
  * we replace them with its value which is also an array.
+ *
+ * Note, if https://github.com/mdn/stumptown-content/issues/118 resolves
+ * with a solution already in the stumptown-content packaged content,
+ * this whole function becomes useless and can be removed.
  */
 function fixAdditionalProse(document) {
   if (document.body) {

--- a/cli/index.js
+++ b/cli/index.js
@@ -50,6 +50,20 @@ function fixRelatedContentURIs(document) {
   });
 }
 
+/** Flatten 'additional_prose' sections.
+ * Basically if the document.body has any sections called 'additional_prose'
+ * we replace them with its value which is also an array.
+ */
+function fixAdditionalProse(document) {
+  if (document.body) {
+    document.body.forEach((section, i) => {
+      if (section.type === "additional_prose") {
+        document.body.splice(i, 1, ...section.value);
+      }
+    });
+  }
+}
+
 function buildHtmlAndJson({ filePath, output, buildHtml, quiet }) {
   const data = fs.readFileSync(filePath, "utf8");
   // const buildHash = crypto
@@ -63,6 +77,8 @@ function buildHtmlAndJson({ filePath, output, buildHtml, quiet }) {
 
   // A temporary fix for the mdn_url values in the related_content.
   fixRelatedContentURIs(options.document);
+
+  fixAdditionalProse(options.document);
 
   const uri = mapToURI(options.document);
 

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -138,23 +138,14 @@ function SidebarLeaf({ depth, title, content }) {
 const PROSE_NO_HEADING = ["short_description", "overview"];
 
 function RenderDocumentBody({ document }) {
-  const sections = [];
-  /**
-   * The reason we can't return a filtered map of 'document.body' is because
-   * some of the parts of 'document.body' is an array.
-   * E.g. document.body.additional_prose == [
-   *     {type: 'prose', value: STUFF},
-   *     {type: 'prose', value: OTHER_STUFF},
-   * ]
-   */
-  document.body.forEach((section, i) => {
+  return document.body.map((section, i) => {
     if (section.type === "prose") {
       // Only exceptional few should use the <Prose/> component,
       // as opposed to <ProseWithHeading/>.
       if (PROSE_NO_HEADING.includes(section.value.id)) {
-        sections.push(<Prose key={section.value.id} section={section.value} />);
+        return <Prose key={section.value.id} section={section.value} />;
       } else {
-        sections.push(
+        return (
           <ProseWithHeading
             key={section.value.id}
             id={section.value.id}
@@ -162,21 +153,8 @@ function RenderDocumentBody({ document }) {
           />
         );
       }
-    } else if (section.type === "additional_prose") {
-      section.value.forEach((subsection, j) => {
-        if (subsection.type === "prose" && subsection.value) {
-          sections.push(
-            <ProseWithHeading
-              key={`${subsection.title}${i}${j}`}
-              section={subsection.value}
-            />
-          );
-        } else {
-          console.warn("Don't know how to deal with subsection:", subsection);
-        }
-      });
     } else if (section.type === "interactive_example") {
-      sections.push(
+      return (
         <InteractiveExample
           key={section.value}
           src={section.value}
@@ -184,30 +162,27 @@ function RenderDocumentBody({ document }) {
         />
       );
     } else if (section.type === "attributes") {
-      sections.push(
-        <Attributes key={`attributes${i}`} attributes={section.value} />
-      );
+      return <Attributes key={`attributes${i}`} attributes={section.value} />;
     } else if (section.type === "browser_compatibility") {
-      sections.push(
+      return (
         <BrowserCompatibilityTable
           key="browser_compatibility"
           data={section.value}
         />
       );
     } else if (section.type === "examples") {
-      sections.push(<Examples key={`examples${i}`} examples={section.value} />);
+      return <Examples key={`examples${i}`} examples={section.value} />;
     } else if (section.type === "info_box") {
       // XXX Unfinished!
       // https://github.com/mdn/stumptown-content/issues/106
       console.warn("Don't know how to deal with info_box!");
       // console.log(section);
+      return null;
     } else {
       console.warn(section);
       throw new Error(`No idea how to handle a '${section.type}' section`);
     }
   });
-
-  return sections;
 }
 
 function Prose({ section }) {


### PR DESCRIPTION
Maybe this was unnecessary had I just waited for https://github.com/mdn/stumptown-content/issues/118 to resolve. 
However, I still wanted to change how the `RenderDocumentBody` component works so it doesn't have to use a `forEach` and just use a `map` instead.