### PR TITLE
Sidebar adjustments

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -99,12 +99,7 @@ function RenderSideBar({ document }) {
 }
 
 function SidebarLeaf({ depth, title, content }) {
-  const titleTag =
-    {
-      0: "h3",
-      1: "h4",
-      2: "h5"
-    }[depth] || "h6";
+  const titleTag = "h3";
   const titleNode = React.createElement(titleTag, null, title);
   return (
     <div>
@@ -114,11 +109,7 @@ function SidebarLeaf({ depth, title, content }) {
           if (node.content) {
             return (
               <li key={node.title}>
-                <SidebarLeaf
-                  depth={depth + 1}
-                  title={node.title}
-                  content={node.content || []}
-                />
+                <SidebarLeaflets node={node} />
               </li>
             );
           } else {
@@ -131,6 +122,23 @@ function SidebarLeaf({ depth, title, content }) {
         })}
       </ul>
     </div>
+  );
+}
+
+function SidebarLeaflets({ node }) {
+  return (
+    <details>
+      <summary>{node.title}</summary>
+      <ol>
+        {node.content.map(childNode => {
+          return (
+            <li key={childNode.uri}>
+              <Link to={childNode.uri}>{childNode.title}</Link>
+            </li>
+          );
+        })}
+      </ol>
+    </details>
   );
 }
 

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -98,9 +98,8 @@ function RenderSideBar({ document }) {
   ));
 }
 
-function SidebarLeaf({ depth, title, content }) {
-  const titleTag = "h3";
-  const titleNode = React.createElement(titleTag, null, title);
+function SidebarLeaf({ title, content }) {
+  const titleNode = <h3>{title}</h3>;
   return (
     <div>
       {titleNode}

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -1,3 +1,6 @@
+$sidebar-summary-color: #333;
+$sidebar-link-color: #3d7e9a;
+
 * {
   box-sizing: border-box;
 }
@@ -39,9 +42,10 @@ div.sidebar {
     padding-left: 20px;
 
     summary {
-      color: #333;
+      color: $sidebar-summary-color;
       display: inline-block;
       margin-right: 5px;
+      cursor: pointer;
     }
 
     summary::-webkit-details-marker {
@@ -53,7 +57,7 @@ div.sidebar {
       content: "▶︎";
       display: inline-block;
       width: 20px;
-      color: #3d7e9a;
+      color: $sidebar-link-color;
     }
   }
 
@@ -72,7 +76,7 @@ div.sidebar {
       padding-bottom: 10px;
 
       a {
-        color: #3d7e9a;
+        color: $sidebar-link-color;
         display: inline-block;
         max-width: 100%;
         position: relative;

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -10,6 +10,11 @@ h1.page-title {
 div.sidebar {
   float: left;
   max-width: 300px;
+  margin-bottom: 20px;
+  position: relative;
+  overflow: hidden;
+  font-size: 16px;
+  font-size: .88889rem;
 
   h3, h4, h5, h6 {
     // The main content area might not start with a <hX> tag.
@@ -25,6 +30,60 @@ div.sidebar {
     li {
       list-style: none;
       margin-top: 20px;
+    }
+  }
+
+  details {
+    margin-bottom: 10px;
+    margin-left: 0;
+    padding-left: 20px;
+
+    summary {
+      color: #333;
+      display: inline-block;
+      margin-right: 5px;
+    }
+
+    summary::-webkit-details-marker {
+      display:none;
+    }
+
+
+    summary:before {
+      content: "▶︎";
+      display: inline-block;
+      width: 20px;
+      color: #3d7e9a;
+    }
+  }
+
+  details[open]>summary:before {
+    content: '\25BC\FE0E';
+  }
+
+  ol {
+    list-style-type: none;
+    padding-left: 20px;
+
+    li {
+      padding-left: 0;
+      margin-top: 0;
+      line-height: 1.2;
+      padding-bottom: 10px;
+
+      a {
+        color: #3d7e9a;
+        display: inline-block;
+        max-width: 100%;
+        position: relative;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        hyphens: auto;
+      }
+    }
+
+    li:first-child {
+      padding-top: 10px;
     }
   }
 }


### PR DESCRIPTION
This should make the sidebar look a bit more like the production site. Originally i was going to check the depth before either rendering the "leaflets" or just another leaf, but found that at the depth of the content when it gets to that point it should always use the `details` tags if a content array is present. I couldn't find an example on the prod site that nested further than this.