### PR TITLE
Make part of URI in BreadcrumbURI able to wrap

### DIFF
--- a/client/src/search.scss
+++ b/client/src/search.scss
@@ -76,6 +76,9 @@ form.search-widget {
     mark {
       background-color: #f3f7bd;
     }
+    small {
+      overflow-wrap: break-word;
+    }
 
     a {
       text-overflow: ellipsis;


### PR DESCRIPTION
Addresses #117 although the original issue reported there is no longer present.

---

# Before

In both Firefox (69.0.1) and Chrome (Chromium 77.0.3865.75), if I have a page with a very long file name (example below), the URI part of search result will overflow

![Annotation 2019-09-24 231008](https://user-images.githubusercontent.com/3090380/65524801-06a67d80-df21-11e9-87d2-63c4fed931d5.png)

![Annotation 2019-09-24 230953](https://user-images.githubusercontent.com/3090380/65524764-f2628080-df20-11e9-8092-77524c83bb24.png)

# After

Applying [`overflow-wrap: break-word;`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap), solves this issue.

![Annotation 2019-09-24 230926](https://user-images.githubusercontent.com/3090380/65524878-2a69c380-df21-11e9-9849-860566da1e7a.png)
![Annotation 2019-09-24 230940](https://user-images.githubusercontent.com/3090380/65524880-2a69c380-df21-11e9-9821-03ef5f6acc7a.png)

