### PR TITLE
Use short titles (where present) in sidebar leaflets

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -132,7 +132,9 @@ function SidebarLeaflets({ node }) {
         {node.content.map(childNode => {
           return (
             <li key={childNode.uri}>
-              <Link to={childNode.uri}>{childNode.title}</Link>
+              <Link to={childNode.uri}>
+                {childNode.short_title || childNode.title}
+              </Link>
             </li>
           );
         })}


### PR DESCRIPTION
stumptown-content now supports `short_title`. This PR uses them inside `<details>` elements in the sidebar, if they exist, falling back to `title` if they don't.
