### PR TITLE
simplify deployment build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Needed for when dependabot makes PRs. Their branches are added here to the 'mdn' repo. 
+# Needed for when dependabot makes PRs. Their branches are added here to the 'mdn' repo.
 branches:
   only:
     - master
@@ -33,5 +33,5 @@ matrix:
     - name: end-to-end
       cache: yarn
       script:
-        - yarn build-content
+        - set -x
         - yarn deployment-build

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ the browser to see the effect immediately. If you want re-build the
 content made available to the `React` components, open another terminal
 and run:
 
-    yarn build-content
+    yarn build
 
 To re-run any of the installation and build steps you can, at any time,
 run:
@@ -204,9 +204,9 @@ host your static site. Build everything with:
 
     yarn deployment-build
 
-What it does is a mix of `yarn workspace server start` and 
+What it does is a mix of `yarn workspace server start` and
 `yarn workspace client start` but without starting a server. It also,
-builds a `index.html` file for every document found and processed by the 
+builds a `index.html` file for every document found and processed by the
 `cli`. This whole directory is ready to be uploaded to S3 or Netlify.
 
 ## Goals and Not-Goals

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "prettier-format": "prettier --write **/*.{js,jsx,scss,css,html}",
     "test": "yarn prettier-check && yarn workspace cli test && yarn workspace client test",
     "build": "cd stumptown && npm run build-json html && cd .. && yarn workspace client build && yarn workspace cli start",
-    "build-content": "cd stumptown && npm run build-json html && cd .. && yarn workspace cli start",
     "deployment-build": "cross-env CLI_BUILD_HTML=true yarn build",
     "start": "nf start"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier-check": "prettier --check **/*.{js,jsx,scss,css,html}",
     "prettier-format": "prettier --write **/*.{js,jsx,scss,css,html}",
     "test": "yarn prettier-check && yarn workspace cli test && yarn workspace client test",
-    "build": "yarn workspace client build && yarn workspace cli start && cd stumptown && npm run build-json html",
+    "build": "cd stumptown && npm run build-json html && cd .. && yarn workspace client build && yarn workspace cli start",
     "build-content": "cd stumptown && npm run build-json html && cd .. && yarn workspace cli start",
     "deployment-build": "cross-env CLI_BUILD_HTML=true yarn build",
     "start": "nf start"


### PR DESCRIPTION
The `yarn build-content` script is going out of fashion. All it does is converts stumptown's packaged json into the necessary .json that the React client needs. It's only really needed one time and we already get it from `yarn build`. 