### PR TITLE
'yarn deployment-build' isn't exiting early

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -296,10 +296,6 @@ function run(paths) {
     expandFiles(paths).map(filePath => {
       const output = args.output;
       return accessFile(filePath, fs.constants.R_OK)
-        .catch(err => {
-          console.error(err.toString());
-          process.exit(1);
-        })
         .then(() => {
           return buildHtmlAndJson({
             filePath,
@@ -307,6 +303,10 @@ function run(paths) {
             buildHtml: args["build-html"],
             quiet: args["quiet"]
           });
+        })
+        .catch(ex => {
+          console.error(ex);
+          throw ex;
         });
     })
   ).then(async values => {
@@ -417,5 +417,7 @@ if (args.watch) {
     }
   });
 } else {
-  run(paths);
+  run(paths).catch(() => {
+    process.exitCode = 1;
+  });
 }

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -186,15 +186,14 @@ function RenderDocumentBody({ doc }) {
     } else if (section.type === "info_box") {
       // XXX Unfinished!
       // https://github.com/mdn/stumptown-content/issues/106
-      // console.warn("Don't know how to deal with info_box!");
-      // console.log(section);
+      console.warn("Don't know how to deal with info_box!");
       return null;
     } else if (section.type === "link_list") {
       return (
         <LinkList title={section.value.title} links={section.value.content} />
       );
     } else {
-      // console.warn(section);
+      console.warn(section);
       throw new Error(`No idea how to handle a '${section.type}' section`);
     }
   });

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -186,7 +186,7 @@ function RenderDocumentBody({ doc }) {
     } else if (section.type === "info_box") {
       // XXX Unfinished!
       // https://github.com/mdn/stumptown-content/issues/106
-      console.warn("Don't know how to deal with info_box!");
+      // console.warn("Don't know how to deal with info_box!");
       // console.log(section);
       return null;
     } else if (section.type === "link_list") {
@@ -194,7 +194,7 @@ function RenderDocumentBody({ doc }) {
         <LinkList title={section.value.title} links={section.value.content} />
       );
     } else {
-      console.warn(section);
+      // console.warn(section);
       throw new Error(`No idea how to handle a '${section.type}' section`);
     }
   });


### PR DESCRIPTION
Fixes #155

This one was tricky. Promises and async/await is fine until you actually need to really care and do something sane with the possible exceptions. Errors thrown deep inside `client/src/*.js` in some React component is totally something that's going to happen from time to time as we're making mistakes. What matters here is that we deal with it properly in the `cli`. What also matters here is that if *any* error happens, it should break the build. I.e. the `cli` should fail with a non-zero exit code. 

Here's the output of running this patch:

```
▶ CLI_BUILD_HTML=true yarn workspace cli start

<snipped to save space>

Rendering HTML failed!
      uri=/en-US/docs/Web/HTML
      filePath=/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/stumptown/packaged/html/HTML.json
Error: No idea how to handle a 'link_list' section
    at /Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:191:13
    at Array.map (<anonymous>)
    at map (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:148:19)
    at processChild (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3090:1)
    at resolve (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3013:1)
    at ReactDOMServerRenderer.render (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3436:1)
    at ReactDOMServerRenderer.read (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3395:1)
    at renderToString (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3954:1)
    at ./render.js.__webpack_exports__.default (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/render.js:31:34)
    at buildHtmlAndJson (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/index.js:118:24)
Rendering HTML failed!
      uri=/en-US/docs/HTML/Elements
      filePath=/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/stumptown/packaged/html/reference/elements.json
Error: No idea how to handle a 'link_list' section
    at /Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:191:13
    at Array.map (<anonymous>)
    at map (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:148:19)
    at processChild (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3090:1)
    at resolve (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3013:1)
    at ReactDOMServerRenderer.render (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3436:1)
    at ReactDOMServerRenderer.read (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3395:1)
    at renderToString (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3954:1)
    at ./render.js.__webpack_exports__.default (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/render.js:31:34)
    at buildHtmlAndJson (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/index.js:118:24)
Rendering HTML failed!
      uri=/en-US/docs/Web/HTML/Applying_color
      filePath=/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/stumptown/packaged/html/guides/Applying_color.json
Error: No idea how to handle a 'example' section
    at /Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:191:13
    at Array.map (<anonymous>)
    at map (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/.ent/src/document.js:148:19)
    at processChild (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3090:1)
    at resolve (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3013:1)
    at ReactDOMServerRenderer.render (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3436:1)
    at ReactDOMServerRenderer.read (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3395:1)
    at renderToString (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/node_modules/react-dom/cjs/react-dom-server.node.development.js:3954:1)
    at ./render.js.__webpack_exports__.default (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/render.js:31:34)
    at buildHtmlAndJson (/Users/peterbe/dev/MOZILLA/MDN/stumptown-renderer/cli/dist/webpack:/index.js:118:24)
Wrote ../client/build/en-US/docs/Web/HTML/Element/address/index.json and ../client/build/en-US/docs/Web/HTML/Element/address/index.html 184ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/abbr/index.json and ../client/build/en-US/docs/Web/HTML/Element/abbr/index.html 91ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/aside/index.json and ../client/build/en-US/docs/Web/HTML/Element/aside/index.html 34ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/article/index.json and ../client/build/en-US/docs/Web/HTML/Element/article/index.html 39ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/b/index.json and ../client/build/en-US/docs/Web/HTML/Element/b/index.html 24ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/audio/index.json and ../client/build/en-US/docs/Web/HTML/Element/audio/index.html 99ms

<snipped to save space>

Wrote ../client/build/en-US/docs/Web/HTML/Element/li/index.json and ../client/build/en-US/docs/Web/HTML/Element/li/index.html 22ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/legend/index.json and ../client/build/en-US/docs/Web/HTML/Element/legend/index.html 18ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/video/index.json and ../client/build/en-US/docs/Web/HTML/Element/video/index.html 60ms
Wrote ../client/build/en-US/docs/Web/HTML/Element/table/index.json and ../client/build/en-US/docs/Web/HTML/Element/table/index.html 60ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
```

What's happening is that I happen to know that there are 3 documents in stumptown/packaged/ that are currently incompatible with our stumptown-renderer React code. It's fine. We'll deal with it when time allows. 

But the critical thing is that all 3 stacktraces are printed with `console.error`. I think this'll help when you're reviewing the full logs on something like TravisCI. Naive use of `Promise.all(promises).then(values => { ... }).catch(err => { console.log('At least one failed!'); console.error(err) }` sucks because you only get to see 1 error.

And most critically, the final `run(paths).catch()` means that at a low level we get to know that 1 or more threw so we have to exit with non-zero. 