### PR TITLE
Render Link Lists

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -5,6 +5,7 @@ import { NoMatch } from "./routing";
 import { InteractiveExample } from "./ingredients/interactive-example";
 import { Attributes } from "./ingredients/attributes";
 import { Example, Examples } from "./ingredients/examples";
+import { LinkList } from "./ingredients/link-list";
 import { BrowserCompatibilityTable } from "./ingredients/browser-compatibility-table";
 
 export class Document extends React.Component {
@@ -188,6 +189,10 @@ function RenderDocumentBody({ doc }) {
       console.warn("Don't know how to deal with info_box!");
       // console.log(section);
       return null;
+    } else if (section.type === "link_list") {
+      return (
+        <LinkList title={section.value.title} links={section.value.content} />
+      );
     } else {
       console.warn(section);
       throw new Error(`No idea how to handle a '${section.type}' section`);

--- a/client/src/ingredients/link-list.js
+++ b/client/src/ingredients/link-list.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Link } from "@reach/router";
+
+export function LinkList({ title, links }) {
+  return (
+    <div className="link-list">
+      <h2>{title}</h2>
+      <dl>
+        {links.map(link => (
+          <React.Fragment key={link.mdn_url}>
+            <dt>
+              <Link to={link.mdn_url}>{link.short_title || link.title}</Link>
+            </dt>
+            {link.short_description && (
+              <dd
+                dangerouslySetInnerHTML={{ __html: link.short_description }}
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -146,6 +146,10 @@ div.content {
     padding: 6px;
     border-radius: 3px;
   }
+
+  .link-list {
+    h2 { border-bottom: 1px solid #eaecef; }
+  }
 }
 
 .external-icon:not([href^='https://mdn.mozillademos.org']):not(.ignore-external) {


### PR DESCRIPTION
#### Please don't merge until https://github.com/mdn/stumptown-renderer/pull/156 is merged into master. 

This will allow link list sections to render properly. Partially satisfies https://github.com/mdn/stumptown-renderer/issues/157

Might style this differently, but i think because it's important to support all the sections in the current version of stumptown-content I wanted to get a functional piece in there for this type of section. Any feedback on this is much appreciated.