### PR TITLE
Render 'link_list' sections

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -96,6 +96,20 @@ function fixDocumentStructure(document) {
   });
 }
 
+/** Take the opportunity here to sanity check every document.body[].link_list
+ * section. By doing it here in the cli we can avoid doing these checks
+ * in the runtime code that is shipped.
+ */
+function checkLinkLists(doc) {
+  doc.body
+    .filter(section => section.type === "link_list")
+    .forEach(section => {
+      if (!section.value.content.length) {
+        throw new Error(`LinkList with an empty list of links (${doc.title})`);
+      }
+    });
+}
+
 /** Pretty print the absolute path relative to the current directory. */
 function ppPath(filePath) {
   return path.relative(process.cwd(), filePath);
@@ -117,6 +131,11 @@ function buildHtmlAndJson({ filePath, output, buildHtml, quiet }) {
    * renderer. This is our chance to fix that specifically for the renderer.
    */
   fixDocumentStructure(options.doc);
+
+  /** To avoid attempting to render `link_list` sections that have no
+   * links in runtime, we check it here first.
+   */
+  checkLinkLists(options.doc);
 
   // Find blocks of syntax code and transform it to syntax highlighted code.
   if (options.doc.body) {

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -5,6 +5,7 @@ import { NoMatch } from "./routing";
 import { InteractiveExample } from "./ingredients/interactive-example";
 import { Attributes } from "./ingredients/attributes";
 import { Examples } from "./ingredients/examples";
+import { LinkList } from "./ingredients/linklist";
 import { BrowserCompatibilityTable } from "./ingredients/browser-compatibility-table";
 
 export class Document extends React.Component {
@@ -186,6 +187,10 @@ function RenderDocumentBody({ doc }) {
       console.warn("Don't know how to deal with info_box!");
       // console.log(section);
       return null;
+    } else if (section.type === "link_list") {
+      return (
+        <LinkList title={section.value.title} content={section.value.content} />
+      );
     } else {
       console.warn(section);
       throw new Error(`No idea how to handle a '${section.type}' section`);

--- a/client/src/ingredients/linklist.js
+++ b/client/src/ingredients/linklist.js
@@ -2,9 +2,6 @@ import React from "react";
 import { Link } from "@reach/router";
 
 export function LinkList({ title, content }) {
-  if (!content.length) {
-    throw new Error(`LinkList with an empty list of links (${title})`);
-  }
   return (
     <>
       <h2>{title}</h2>

--- a/client/src/ingredients/linklist.js
+++ b/client/src/ingredients/linklist.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { Link } from "@reach/router";
+
+export function LinkList({ title, content }) {
+  if (!content.length) {
+    throw new Error(`LinkList with an empty list of links (${title})`);
+  }
+  return (
+    <>
+      <h2>{title}</h2>
+      <dl>
+        {content.map(link => {
+          return (
+            <React.Fragment key={link.uri}>
+              <dt>
+                <Link to={link.uri}>{link.short_title || link.title}</Link>
+              </dt>
+              {link.short_description && <dd>{link.short_description}</dd>}
+            </React.Fragment>
+          );
+        })}
+      </dl>
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #157

<img width="1616" alt="Screen Shot 2019-10-01 at 11 40 58 AM" src="https://user-images.githubusercontent.com/26739/65979727-c9238200-e443-11e9-879f-342d0695393a.png">

It looks a bit odd that none of those have a `short_description` but I guess that'll come later. 