### PR TITLE
Move scripts from body to head

### DIFF
--- a/cli/render.js
+++ b/cli/render.js
@@ -54,5 +54,11 @@ export default (renderApp, options) => {
   // Every script tag that create-react-app inserts, make them defer
   $("body script[src]").attr("defer", "");
 
+  // Move the script tags from the body to the head.
+  // That way the browser can notice, and start downloading these files sooner
+  // but they'll still be executed after the first render.
+  $("body script[src]").appendTo("head");
+  $("body script[src]").remove();
+
   return $.html();
 };


### PR DESCRIPTION
Fixes #104

At the rendered html, now the scripts (which already have `defer` attribute) are put at the end of `<head>` instead of end of `<body>`.

Example of html output:

![Annotation 2019-10-02 220224](https://user-images.githubusercontent.com/3090380/66050881-90c59600-e560-11e9-89d9-d02412781c3e.png)

Question: should the `documentData` be moved to head too? 