### PR TITLE
Support locale for titles

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -311,29 +311,40 @@ function run(paths) {
     })
   ).then(async values => {
     console.log(chalk.green(`Built ${values.length} documents.`));
-    const titles = {};
-    // XXX Support locales!
-    const allTitlesFilepath = path.join(STATIC_ROOT, "titles.json");
-    try {
-      titles.titles = JSON.parse(await readFile(allTitlesFilepath, "utf8"));
-      console.warn(
-        `Updating ${Object.keys(allTitles).length} file ${allTitlesFilepath}`
-      );
-    } catch (ex) {
-      // throw ex;
-      console.warn(`Starting a fresh new ${allTitlesFilepath}`);
-      titles.titles = {};
-    }
+    const titlesByLocale = {};
     values.forEach(built => {
-      titles.titles[built.uri] = built.doc.title;
+      const localeKey = built.uri.split("/")[1];
+      titlesByLocale[localeKey] = titlesByLocale[localeKey] || [];
+      titlesByLocale[localeKey].push(built);
     });
+    Object.entries(titlesByLocale).forEach(async ([locale, localeTitles]) => {
+      const titles = {};
+      const allTitlesFilepath = path.join(STATIC_ROOT, `${locale}/titles.json`);
+      try {
+        titles.titles = JSON.parse(await readFile(allTitlesFilepath, "utf8"))[
+          "titles"
+        ];
+        console.warn(
+          `Updating ${
+            Object.keys(titles.titles).length
+          } file ${allTitlesFilepath}`
+        );
+      } catch (ex) {
+        // throw ex;
+        console.warn(`Starting a fresh new ${allTitlesFilepath}`);
+        titles.titles = {};
+      }
+      localeTitles.forEach(built => {
+        titles.titles[built.uri] = built.doc.title;
+      });
 
-    await writeFile(allTitlesFilepath, JSON.stringify(titles, null, 2));
-    console.log(
-      `${allTitlesFilepath} now contains ${Object.keys(
-        titles.titles
-      ).length.toLocaleString()} documents.`
-    );
+      await writeFile(allTitlesFilepath, JSON.stringify(titles, null, 2));
+      console.log(
+        `${allTitlesFilepath} now contains ${Object.keys(
+          titles.titles
+        ).length.toLocaleString()} documents.`
+      );
+    });
     return values;
   });
 }

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -46,6 +46,12 @@ export class SearchWidget extends React.Component {
     }
   };
 
+  getCurrentLocale = () => {
+    return (
+      (this.props.pathname && this.props.pathname.split("/")[1]) || "en-US"
+    );
+  };
+
   componentDidMount() {
     document.addEventListener("keydown", this.focusOnSearchMaybe);
   }
@@ -59,7 +65,8 @@ export class SearchWidget extends React.Component {
           lastQ: "",
           q: "",
           redirectTo: null,
-          showSearchResults: false
+          showSearchResults: false,
+          locale: this.props.pathname.split("/")[1] || "en-US"
         });
       }
     }
@@ -77,7 +84,7 @@ export class SearchWidget extends React.Component {
       // Always do the XHR network request (hopefully good HTTP caching
       // will make this pleasant for the client) but localStorage is
       // always faster than XHR even with localStorage's flaws.
-      const localStorageCacheKey = "titles";
+      const localStorageCacheKey = `${this.getCurrentLocale()}-titles`;
       const storedTitlesRaw = localStorage.getItem(localStorageCacheKey);
       if (storedTitlesRaw) {
         let storedTitles = null;
@@ -97,9 +104,7 @@ export class SearchWidget extends React.Component {
 
       let response;
       try {
-        // XXX support locales!
-        //
-        response = await fetch("/titles.json");
+        response = await fetch(`/${this.getCurrentLocale()}/titles.json`);
       } catch (ex) {
         if (this.dismounted) return;
         return this.setState({ serverError: ex, showSearchResults: true });
@@ -117,9 +122,11 @@ export class SearchWidget extends React.Component {
       // So we can keep track of how old the data is when stored
       // in localStorage.
       titles._fetchDate = new Date().getTime();
-      // XXX support proper cache keys based on locales
       try {
-        localStorage.setItem("titles", JSON.stringify(titles));
+        localStorage.setItem(
+          `${this.getCurrentLocale()}-titles`,
+          JSON.stringify(titles)
+        );
       } catch (ex) {
         console.warn(
           ex,


### PR DESCRIPTION
Fix #148

This PR will store the titles.json files in their respective locale, and the search component will set the correct localStorage key along with fetch the correct titles depending on the locale in the path.

Also fixed how it was "Starting a fresh new file" every time. 