### PR TITLE
Implement error boundary for Browser Compatibility ingredient

### DIFF
--- a/client/src/ingredients/browser-compatibility-table/error-boundary.js
+++ b/client/src/ingredients/browser-compatibility-table/error-boundary.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+/**
+ * The error boundary for BrowserCompatibilityTable.
+ *
+ * When the whole BrowserCompatibilityTable crashes, for whatever reason,
+ * this component will show a friendly message
+ * to replace that crashed component
+ */
+export class BrowserCompatibilityErrorBoundary extends React.Component {
+  state = {
+    error: null
+  };
+  componentDidCatch(error, _errorInfo) {
+    this.setState({
+      error
+    });
+    // TODO: Report this error to Sentry, https://github.com/mdn/stumptown-renderer/issues/99
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <>
+          <div className="bc-table-error-boundary">
+            Unfortunately, this table has encountered unhandled error and the
+            content cannot be shown.
+            {/* TODO: When error reporting is set up, the message should include "We have been notified of this error" or something similar */}
+          </div>
+        </>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/client/src/ingredients/browser-compatibility-table/error-boundary.test.js
+++ b/client/src/ingredients/browser-compatibility-table/error-boundary.test.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { BrowserCompatibilityErrorBoundary } from "./error-boundary.js";
+
+it("renders without crashing", () => {
+  const { container } = render(
+    <BrowserCompatibilityErrorBoundary>
+      <div />
+    </BrowserCompatibilityErrorBoundary>
+  );
+  expect(container).toBeDefined();
+});
+
+it("renders crashing mock component", () => {
+  const CrashingComponent = function() {
+    const [crashing, setCrashing] = React.useState(false);
+
+    if (crashing) {
+      throw new Error("42");
+    }
+    return (
+      <div
+        onClick={() => {
+          setCrashing(true);
+        }}
+      />
+    );
+  };
+
+  const { container } = render(
+    <BrowserCompatibilityErrorBoundary>
+      <CrashingComponent />
+    </BrowserCompatibilityErrorBoundary>
+  );
+  expect(container.querySelector(".bc-table-error-boundary")).toBeNull();
+  const div = container.querySelector("div");
+  fireEvent.click(div);
+
+  // TODO: When `BrowserCompatibilityErrorBoundary` reports to Sentry, spy on the report function so that we can assert the error stack
+  expect(container.querySelector(".bc-table-error-boundary")).toBeDefined();
+});

--- a/client/src/ingredients/browser-compatibility-table/index.js
+++ b/client/src/ingredients/browser-compatibility-table/index.js
@@ -4,6 +4,7 @@ import { Browsers } from "./browsers";
 import { Rows } from "./rows";
 import { Legend } from "./legend";
 import "./bcd.scss";
+import { BrowserCompatibilityErrorBoundary } from "./error-boundary";
 
 const BROWSERS = {
   desktop: ["chrome", "edge", "firefox", "ie", "opera", "safari"],
@@ -20,7 +21,7 @@ const BROWSERS = {
   "webextensions-mobile": ["firefox_android"]
 };
 
-export class BrowserCompatibilityTable extends Component {
+class BrowserCompatibilityTableContent extends Component {
   state = {
     currentNoteId: null,
     hasDeprecation: false,
@@ -91,7 +92,6 @@ export class BrowserCompatibilityTable extends Component {
     );
     return (
       <>
-        {data.title && <h2 id={data.id}>{data.title}</h2>}
         <a
           className="bc-github-link external external-icon"
           href="https://github.com/mdn/browser-compat-data"
@@ -127,3 +127,14 @@ export class BrowserCompatibilityTable extends Component {
     );
   }
 }
+
+export const BrowserCompatibilityTable = props => {
+  return (
+    <BrowserCompatibilityErrorBoundary>
+      {props.data && props.data.title && (
+        <h2 id={props.data.id}>{props.data.title}</h2>
+      )}
+      <BrowserCompatibilityTableContent {...props} />
+    </BrowserCompatibilityErrorBoundary>
+  );
+};

--- a/client/src/ingredients/browser-compatibility-table/index.test.js
+++ b/client/src/ingredients/browser-compatibility-table/index.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { BrowserCompatibilityTable } from "./index.js";
+
+it("renders error boundary when no data is present", () => {
+  const { container } = render(<BrowserCompatibilityTable />);
+  expect(container.querySelector(".bc-table")).toBeNull();
+  expect(container.querySelector(".bc-table-error-boundary")).toBeDefined();
+  // TODO: When `BrowserCompatibilityErrorBoundary` reports to Sentry, spy on the report function so that we can assert the error stack
+});


### PR DESCRIPTION
Fixes #144 

Per discussion there, finally settled for error boundary only for the Browser Compatibility Table ingredient.

![Annotation 2019-10-12 091101](https://user-images.githubusercontent.com/3090380/66692356-3c44b800-ecd0-11e9-893a-348b5fb7e036.png)


The light red color comes from [react-error-overlay](https://github.com/facebook/create-react-app/tree/master/packages/react-error-overlay)