### PR TITLE
Simplify expandFiles

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -248,7 +248,7 @@ if (!paths.length) {
  * Only if it's a directory do we search for *.json files in all its subdirectories
  */
 function expandFiles(directoriesOrFiles) {
-  const filePaths = [];
+  const filePaths = new Set();
   for (
     let discoveredPaths = directoriesOrFiles.slice(),
       currentPath = discoveredPaths.pop();
@@ -267,10 +267,10 @@ function expandFiles(directoriesOrFiles) {
         ...fs.readdirSync(currentPath).map(p => path.join(currentPath, p))
       );
     } else if (path.extname(currentPath) === ".json") {
-      filePaths.push(currentPath);
+      filePaths.add(currentPath);
     }
   }
-  return filePaths;
+  return Array.from(filePaths);
 }
 
 function run(paths) {


### PR DESCRIPTION
Based on my comments in #185 

This also changes the API a bit, which is why it's still a draft. Namely the implementation on master supports passing in non-JSON files. If that's actually needed and you're happy with the change, I'll put it back in, @peterbe.