### PR TITLE
Don't run install for lockfile-check job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ cache:
 before_install:
   - npm install -g yarn
   - yarn --version
-  # All nodes of the matrix will need and benefit from this
-  - yarn
 
 matrix:
   include:
@@ -37,6 +35,6 @@ matrix:
         - yarn deployment-build
         - yarn end-to-end-test
     - name: lockfile-check
-      cache: yarn
+      install: skip
       script:
         - ./scripts/ci-yarn-lockfile-check.sh

--- a/scripts/ci-yarn-lockfile-check.sh
+++ b/scripts/ci-yarn-lockfile-check.sh
@@ -5,12 +5,12 @@
 # Taken from https://github.com/yarnpkg/yarn/issues/4098#issuecomment-492729443
 
 CKSUM_BEFORE=$(cksum yarn.lock)
-yarn install
+yarn install --ignore-scripts
 EXIT_CODE=$?
 CKSUM_AFTER=$(cksum yarn.lock)
 
 if [[ $CKSUM_BEFORE != $CKSUM_AFTER ]]; then
-  echo "yarn_frozen_lockfile.sh: yarn.lock was modified unexpectedly - terminating"
+  echo "yarn.lock was modified unexpectedly - terminating"
   exit 1
 fi
 


### PR DESCRIPTION
Had to add a config param to skip install. Also removed the before_install `yarn` as that happens by default for all jobs anyways.