### PR TITLE
Add renderer support for JS; update stumptown submodule with JS content

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -8,7 +8,7 @@ import { Prose, ProseWithHeading } from "./ingredients/prose";
 import { InteractiveExample } from "./ingredients/interactive-example";
 import { Attributes } from "./ingredients/attributes";
 import { Examples } from "./ingredients/examples";
-import { LinkLists } from "./ingredients/link-lists";
+import { LinkList, LinkLists } from "./ingredients/link-lists";
 import { Specifications } from "./ingredients/specifications";
 import { BrowserCompatibilityTable } from "./ingredients/browser-compatibility-table";
 
@@ -208,6 +208,17 @@ function RenderDocumentBody({ doc }) {
       // https://github.com/mdn/stumptown-content/issues/106
       console.warn("Don't know how to deal with info_box!");
       return null;
+    } else if (
+      section.type === "static_methods" ||
+      section.type === "instance_methods"
+    ) {
+      return (
+        <LinkList
+          key={`${section.type}${i}`}
+          title={section.value.title}
+          links={section.value.content}
+        />
+      );
     } else if (section.type === "link_lists") {
       return <LinkLists key={`linklists${i}`} lists={section.value} />;
     } else {

--- a/client/src/ingredients/link-lists.js
+++ b/client/src/ingredients/link-lists.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "@reach/router";
 
-function LinkList({ title, links }) {
+export function LinkList({ title, links }) {
   return (
     <div className="link-list">
       <h2>{title}</h2>


### PR DESCRIPTION
This PR updates the renderer so it knows how to render JS class pages, which contain lists of methods.

It also updates the `stumptown` submodule to one that actually contains some content for one of these things, and its subpages. So you should see it at http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt.