### PR TITLE
BCD Table Links

### DIFF
--- a/cli/browser-compatibility-table.js
+++ b/cli/browser-compatibility-table.js
@@ -1,22 +1,36 @@
-export function fixMdnURL(document) {
-  // Loop over, and mutate, all 'browser_compatibility' sections
-  document.body
+const url = require("url");
+
+export function normalizeURLs(doc) {
+  // Loop over, and mutate, all 'browser_compatibility' sections.
+  // BCD data comes froms from a library with `mdn_url`'s that are absolute.
+  // This takes the `mdn_url` and sets it to a URI that can be used when
+  // rendering the BCD table to link to a relative path.
+  doc.body
     .filter(section => section.type === "browser_compatibility")
     .forEach(section => {
-      Object.entries(section.value.data).forEach(([key, block]) => {
-        if (!!block.__compat) {
+      Object.entries(section.value.data).forEach(([, block]) => {
+        // First block from the BCD data does not have its name as the root key
+        // so mdn_url is accessible at the root. If the block has a key for
+        // `__compat` it is not the first block, and the information is nested
+        // under `__compat`.
+        if (block.__compat) {
           block = block.__compat;
         }
-        if (!!block.mdn_url) {
-          block.mdn_url = mutateURL(block.mdn_url);
+        if (block.mdn_url) {
+          block.mdn_url = getPathFromAbsoluteURL(block.mdn_url);
         }
       });
     });
 }
 
-function mutateURL(mdn_url) {
-  return mdn_url
-    .split("/")
-    .slice(4)
-    .join("/");
+function getPathFromAbsoluteURL(absURL) {
+  const u = url.parse(absURL);
+  if (u.hostname !== "developer.mozilla.org") {
+    // If URL is from a different host, return without modifying it
+    return absURL;
+  }
+  // Return the pathname without docs directory, the base path for the
+  // `Document` component the BCD table is within is /:locale/docs/ so it is
+  // not needed.
+  return u.pathname.replace("/docs/", "");
 }

--- a/cli/browser-compatibility-table.js
+++ b/cli/browser-compatibility-table.js
@@ -1,0 +1,22 @@
+export function fixMdnURL(document) {
+  // Loop over, and mutate, all 'browser_compatibility' sections
+  document.body
+    .filter(section => section.type === "browser_compatibility")
+    .forEach(section => {
+      Object.entries(section.value.data).forEach(([key, block]) => {
+        if (!!block.__compat) {
+          block = block.__compat;
+        }
+        if (!!block.mdn_url) {
+          block.mdn_url = mutateURL(block.mdn_url);
+        }
+      });
+    });
+}
+
+function mutateURL(mdn_url) {
+  return mdn_url
+    .split("/")
+    .slice(4)
+    .join("/");
+}

--- a/cli/index.js
+++ b/cli/index.js
@@ -18,6 +18,7 @@ import chalk from "chalk";
 import { App } from "../client/src/app";
 import render from "./render";
 import { fixSyntaxHighlighting } from "./syntax-highlighter";
+import { fixMdnURL } from "./browser-compatibility-table";
 
 const STUMPTOWN_CONTENT_ROOT =
   process.env.STUMPTOWN_CONTENT_ROOT || path.join(__dirname, "../../stumptown");
@@ -126,6 +127,7 @@ function buildHtmlAndJson({ filePath, output, buildHtml, quiet, titles }) {
     // Find blocks of syntax code and transform it to syntax highlighted code.
     if (options.doc.body) {
       fixSyntaxHighlighting(options.doc);
+      fixMdnURL(options.doc);
     }
 
     const outfileHtml = path.join(destination, "index.html");

--- a/cli/index.js
+++ b/cli/index.js
@@ -18,7 +18,7 @@ import chalk from "chalk";
 import { App } from "../client/src/app";
 import render from "./render";
 import { fixSyntaxHighlighting } from "./syntax-highlighter";
-import { fixMdnURL } from "./browser-compatibility-table";
+import { normalizeURLs } from "./browser-compatibility-table";
 
 const STUMPTOWN_CONTENT_ROOT =
   process.env.STUMPTOWN_CONTENT_ROOT || path.join(__dirname, "../../stumptown");
@@ -124,10 +124,12 @@ function buildHtmlAndJson({ filePath, output, buildHtml, quiet, titles }) {
     // of the renderer.
     fixRelatedContent(options.doc);
 
-    // Find blocks of syntax code and transform it to syntax highlighted code.
     if (options.doc.body) {
+      // Find blocks of code and transform it to syntax highlighted code.
       fixSyntaxHighlighting(options.doc);
-      fixMdnURL(options.doc);
+      // Creates new mdn_url's for the browser-compatibility-table to link to
+      // pages within this project rather than use the absolute URLs
+      normalizeURLs(options.doc);
     }
 
     const outfileHtml = path.join(destination, "index.html");

--- a/client/src/ingredients/browser-compatibility-table/bcd.scss
+++ b/client/src/ingredients/browser-compatibility-table/bcd.scss
@@ -1,3 +1,5 @@
+$link-color: #3d7e9a;
+
 .bc-github-link {
   white-space: pre-line;
   float: right;
@@ -106,7 +108,12 @@
   background-color: #eaeef2;
 }
 
+.bc-table tbody th a {
+  color: $link-color;
+}
+
 .bc-table tbody th code {
+  color: unset;
   word-wrap: break-word;
   width: 100%;
   position: relative;

--- a/client/src/ingredients/browser-compatibility-table/rows.js
+++ b/client/src/ingredients/browser-compatibility-table/rows.js
@@ -1,14 +1,18 @@
 import React from "react";
+import { Link } from "@reach/router";
 import { BrowserSupportDetail } from "./browser-support-detail";
 import { BrowserSupportNotes } from "./browser-support-notes";
-import { Link } from "@reach/router";
 
 function buildCompatibilityObject(query, compatibilityData) {
   const features = {};
 
   if (!!compatibilityData.__compat) {
+    // The first row in the BCD data is the overall topic for the page, and
+    // does not have its name within the data. Retrieve the name from the query
+    // data and set a flag so that we do not render a `Link` for it since we
+    // are already on that page.
     const name = query.split(".").pop();
-    features[name] = { ...compatibilityData.__compat, ...{ origin: true } };
+    features[name] = { ...compatibilityData.__compat, ...{ isFirst: true } };
   }
   for (const compat in compatibilityData) {
     if (compat !== "__compat" && !!compatibilityData[compat]["__compat"]) {
@@ -225,7 +229,7 @@ export function Rows({
     browserCompatibilityRows.push([
       <tr key={key}>
         <th scope="row">
-          {currentRow.mdn_url && !currentRow.origin ? (
+          {currentRow.mdn_url && !currentRow.isFirst ? (
             <Link to={currentRow.mdn_url}>
               <code>{key}</code>
             </Link>

--- a/client/src/ingredients/browser-compatibility-table/rows.js
+++ b/client/src/ingredients/browser-compatibility-table/rows.js
@@ -1,13 +1,14 @@
 import React from "react";
 import { BrowserSupportDetail } from "./browser-support-detail";
 import { BrowserSupportNotes } from "./browser-support-notes";
+import { Link } from "@reach/router";
 
 function buildCompatibilityObject(query, compatibilityData) {
   const features = {};
 
   if (!!compatibilityData.__compat) {
     const name = query.split(".").pop();
-    features[name] = compatibilityData.__compat;
+    features[name] = { ...compatibilityData.__compat, ...{ origin: true } };
   }
   for (const compat in compatibilityData) {
     if (compat !== "__compat" && !!compatibilityData[compat]["__compat"]) {
@@ -221,11 +222,16 @@ export function Rows({
       hasAlternative,
       hasNotes
     );
-
     browserCompatibilityRows.push([
       <tr key={key}>
         <th scope="row">
-          <code>{key}</code>
+          {currentRow.mdn_url && !currentRow.origin ? (
+            <Link to={currentRow.mdn_url}>
+              <code>{key}</code>
+            </Link>
+          ) : (
+            <code>{key}</code>
+          )}
           {currentRow.status && (
             <div className="bc-icons">
               {currentRow.status.deprecated && (


### PR DESCRIPTION
Fixes #243 

![Screen Shot 2019-11-21 at 11 09 10 AM](https://user-images.githubusercontent.com/1201062/69355224-6f735300-0c4f-11ea-8661-4852b33653ac.png)
![Screen Shot 2019-11-21 at 11 09 37 AM](https://user-images.githubusercontent.com/1201062/69355233-739f7080-0c4f-11ea-83af-79db240a568b.png)

This mutates the `mdn_url` for browser-compatibility sections and allows you to navigate to the docs linked in the BCD table. 