### PR TITLE
Add --no-progress-bar option

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,7 +7,7 @@ Procfile
 # exclude these directories
 /stumptown/
 /client/build/
-/cli/dist/
+/ssr/dist/
 /node_modules/
 /server/node_modules/
 /client/node_modules/

--- a/cli/index.js
+++ b/cli/index.js
@@ -43,6 +43,12 @@ cli
     cli.BOOL,
     SSR_OPTION_DEFAULTS.quiet
   )
+  .option(
+    "--no-progress-bar",
+    "disable progress bar",
+    cli.BOOL,
+    SSR_OPTION_DEFAULTS.noProgressBar
+  )
   .action((args, options) => runSSR(args.paths, options));
 
 cli.parse(process.argv);

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -229,12 +229,9 @@ function renderDocuments(
    */
   const useProgressBar =
     !quiet &&
-    (JSON.parse(process.env.CI || "false") ||
-      !process.stdout.isTTY ||
-      !noProgressBar);
+    !noProgressBar &&
+    (!JSON.parse(process.env.CI || "false") || !process.stdout.isTTY);
   const printEachBuiltFile = !quiet && !useProgressBar;
-  console.log("useProgressBar", useProgressBar);
-  console.log("printEachBuiltFile", printEachBuiltFile);
 
   const startTime = Date.now();
   const built = [];


### PR DESCRIPTION
Fixes #235

Based on https://github.com/mdn/stumptown-renderer/pull/259#pullrequestreview-325419683, I added `--no-progress-bar` option.

It's more useful to display either progress bar or each built file, but not both.

But if `--quiet` is passed, we should disable both.
