### PR TITLE
break up builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "prettier-check": "prettier --check **/*.{js,json,scss,html}",
     "prettier-format": "prettier --write **/*.{js,json,scss,html}",
     "test": "yarn prettier-check && yarn workspace ssr test && yarn workspace client test",
-    "build": "cd stumptown && npm run build-json && cd .. && yarn workspace client build && yarn workspace ssr build && node cli/index.js ssr --build-html",
+    "build:stumptown": "cd ${STUMPTOWN_CONTENT_ROOT:-stumptown} && npm run build-json",
+    "build:client": "yarn workspace client build",
+    "build:ssr": "yarn workspace ssr build && node cli/index.js ssr --build-html",
+    "build": "yarn run build:stumptown && yarn run build:client && yarn run build:ssr",
     "deployment-build": "cross-env CLI_BUILD_HTML=true yarn build",
     "end-to-end-test": "node scripts/end-to-end-test.js",
     "start": "nf start"


### PR DESCRIPTION
This actually works great! 
Would you mind thinking about how to incorporate this into [your cli commad work](https://github.com/mdn/stumptown-renderer/pull/261)

What's neat about this is that you can now healthy run:
```
▶ export STUMPTOWN_CONTENT_ROOT=~/stumptown-content
▶ yarn build && yarn start
```
and it runs `npm run build-json` for the right stumptown-content and it watches the right files and stuff. 