### PR TITLE
ssr/dist should be prettier ignored

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,7 +7,7 @@ Procfile
 # exclude these directories
 /stumptown/
 /client/build/
-/cli/dist/
+/ssr/dist/
 /node_modules/
 /server/node_modules/
 /client/node_modules/


### PR DESCRIPTION
Part of #260

```
▶ prettier --check "**/*.{js,json,scss,html}"
Checking formatting...
All matched files use Prettier code style!
```
much better. 


