### PR TITLE
lowercase everything everywhere

### DIFF
--- a/scripts/end-to-end-test.js
+++ b/scripts/end-to-end-test.js
@@ -12,7 +12,7 @@ const cheerio = require("cheerio");
    * is sane.
    */
 
-  const directory = "client/build/en-US/docs/Web/HTML/Element/video/";
+  const directory = "client/build/en-us/docs/web/html/element/video/";
   const videoJsonRaw = fs.readFileSync(
     path.join(directory, "index.json"),
     "utf8"

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,15 @@ const app = express();
 // XXX Check that that folder exists and has stuff!
 const STATIC_ROOT = path.join(__dirname, "../client/build");
 
+// Lowercase every request because every possible file we might have
+// on disk is always in lowercase.
+// This only helps when you're on a filesystem (e.g. Linux) that is case
+// sensitive.
+app.use((req, res, next) => {
+  req.url = req.url.toLowerCase();
+  next();
+});
+
 app.use(
   express.static(STATIC_ROOT, {
     // https://expressjs.com/en/4x/api.html#express.static

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -100,7 +100,7 @@ function buildHtmlAndJson({ filePath, output, buildHtml, quiet, titles }) {
   }
   titles[uri] = options.doc.title;
 
-  const destination = path.join(output, uri);
+  const destination = path.join(output, uri.toLowerCase());
 
   fs.mkdirSync(destination, { recursive: true });
 

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -344,7 +344,10 @@ function renderDocuments(
 
   Object.entries(titlesByLocale).forEach(([locale, localeTitles]) => {
     const titles = {};
-    const allTitlesFilepath = path.join(STATIC_ROOT, `${locale}/titles.json`);
+    const allTitlesFilepath = path.join(
+      STATIC_ROOT,
+      `${locale.toLowerCase()}/titles.json`
+    );
     const updateTitlesFiles = fs.existsSync(allTitlesFilepath);
     if (updateTitlesFiles) {
       titles.titles = JSON.parse(fs.readFileSync(allTitlesFilepath, "utf8"))[


### PR DESCRIPTION
Fixes #289 

This way, every file written to disk by the ssr is always in lowercase.

When you use the dev server on `localhost:5000` it won't even notice if you're on macOS or Windows, so I added a little rewrite rule to the express app there to lowercase all requests before they become file lookups. 

We could do more, like redirecting to the correctly spelled case,  but it can wait till some other day. 