### PR TITLE
Run yarn as a pre-commit hook to ensure up-to-date lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ you've run `yarn upgrade prettier --latest` for example):
 
     yarn prettier-format
 
+### Adding dependencies
+
+To add a new NPM dependency into one of the workspaces, start a shell in the root
+directory. From there, type:
+
+    yarn workspace client add some-lib
+    # or...
+    yarn workspace ssr add --dev some-package@1.2.4
+
+This will update the `/yarn.lock` file and your `/node_modules`.
+
+NOTE! Due to a bug in `yarn` v1, you have to run `yarn install --ignore-scripts`
+one extra time so that the `/yarn.lock` file gets corrected. We hope to remove
+this requirement when we can switch to `yarn` v2 in 2020. For now, to make it
+easier for you, we have this added as a `huskey` `pre-commit` hook so simply
+committing your changes will fix it for you automatically.
+
 ## Server-Sider Rendering
 
 Usually, when doing local development work you don't need server-side

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged && yarn install --ignore-scripts"
     }
   }
 }


### PR DESCRIPTION
This fixes the problem of the lockfile not being correctly updated after adding a dependency, by running yarn before committing. On my machine this makes committing ~1s slower (if there's no update to the lockfile required).