### PR TITLE
Render JS sidebar

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, Location } from "@reach/router";
+import { Link } from "@reach/router";
 
 import { NoMatch } from "./routing";
 
@@ -105,84 +105,56 @@ function RenderSideBar({ doc }) {
 }
 
 function SidebarLeaf({ parent }) {
-  const titleNode = <h3>{parent.title}</h3>;
   return (
-    <Location>
-      {({ location }) => {
-        // walk through the tree, annotating its nodes:
-        // * `isActive` if a node contains the link to the current page
-        // * `open` if a node is on the path to the `isActive` node
-        function setOpenNodes(node, pathname) {
-          if (node.uri === pathname) {
-            node.open = true;
-            node.isActive = true;
-            return true;
-          }
+    <div>
+      <h3>{parent.title}</h3>
+      <ul>
+        {parent.content.map(node => {
           if (node.content) {
-            for (const child of node.content) {
-              if (setOpenNodes(child, pathname)) {
-                node.open = true;
-                return true;
-              }
-            }
+            return (
+              <li key={node.title}>
+                <SidebarLeaflets node={node} />
+              </li>
+            );
+          } else {
+            return (
+              <li key={node.uri}>
+                <Link to={node.uri}>{node.title}</Link>
+              </li>
+            );
           }
-          return false;
-        }
-        setOpenNodes(parent, location.pathname);
-
-        return (
-          <div>
-            {titleNode}
-            <ul>
-              {parent.content.map(node => {
-                if (node.content) {
-                  return (
-                    <li key={node.title}>
-                      <SidebarLeaflets node={node} />
-                    </li>
-                  );
-                } else {
-                  return (
-                    <li key={node.uri}>
-                      <Link to={node.uri}>{node.title}</Link>
-                    </li>
-                  );
-                }
-              })}
-            </ul>
-          </div>
-        );
-      }}
-    </Location>
+        })}
+      </ul>
+    </div>
   );
 }
 
 function SidebarLeaflets({ node }) {
-  const listItems = node.content.map(childNode => {
-    if (childNode.content) {
-      return (
-        <li key={childNode.title}>
-          <SidebarLeaflets node={childNode} />
-        </li>
-      );
-    } else {
-      return (
-        <li
-          key={childNode.uri}
-          className={childNode.isActive ? "active" : undefined}
-        >
-          <Link to={childNode.uri}>{childNode.title}</Link>
-        </li>
-      );
-    }
-  });
-
   return (
     <details open={node.open}>
       <summary>
-        {node.uri ? <a href={node.uri}> {node.title}</a> : node.title}
+        {node.uri ? <Link to={node.uri}>{node.title}</Link> : node.title}
       </summary>
-      <ol>{listItems}</ol>
+      <ol>
+        {node.content.map(childNode => {
+          if (childNode.content) {
+            return (
+              <li key={childNode.title}>
+                <SidebarLeaflets node={childNode} />
+              </li>
+            );
+          } else {
+            return (
+              <li
+                key={childNode.uri}
+                className={childNode.isActive && "active"}
+              >
+                <Link to={childNode.uri}>{childNode.title}</Link>
+              </li>
+            );
+          }
+        })}
+      </ol>
     </details>
   );
 }

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -109,6 +109,9 @@ function SidebarLeaf({ parent }) {
   return (
     <Location>
       {({ location }) => {
+        // walk through the tree, annotating its nodes:
+        // * `isActive` if a node contains the link to the current page
+        // * `open` if a node is on the path to the `isActive` node
         function setOpenNodes(node, pathname) {
           if (node.uri === pathname) {
             node.open = true;

--- a/client/src/document.js
+++ b/client/src/document.js
@@ -145,15 +145,26 @@ function SidebarLeaflets({ node }) {
           if (isActive && !hasActiveChild) {
             hasActiveChild = true;
           }
-          return (
-            <li key={childNode.uri} className={isActive ? "active" : undefined}>
-              <Link to={childNode.uri}>{childNode.title}</Link>
-            </li>
-          );
+          if (childNode.content) {
+            return (
+              <li key={childNode.title}>
+                <SidebarLeaflets node={childNode} />
+              </li>
+            );
+          } else {
+            return (
+              <li
+                key={childNode.uri}
+                className={isActive ? "active" : undefined}
+              >
+                <Link to={childNode.uri}>{childNode.title}</Link>
+              </li>
+            );
+          }
         });
 
         return (
-          <details open={!!hasActiveChild}>
+          <details open={true}>
             <summary>{node.title}</summary>
             <ol>{listItems}</ol>
           </details>
@@ -220,6 +231,7 @@ function RenderDocumentBody({ doc }) {
       console.warn("Don't know how to deal with info_box!");
       return null;
     } else if (
+      section.type === "class_constructor" ||
       section.type === "static_methods" ||
       section.type === "instance_methods"
     ) {

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -12,10 +12,13 @@ h1.page-title {
 
 div.sidebar {
   float: left;
+  max-height: 100vh;
   max-width: 300px;
+  position: sticky;
+  top: 0;
   margin-bottom: 20px;
-  position: relative;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
   font-size: 16px;
   font-size: 0.88889rem;
 

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -55,11 +55,11 @@ function fixRelatedContent(document) {
 
     // The sidebar only needs a 'title' and doesn't really care if
     // it came from the full title or the 'short_title'.
-    item.title = item.short_title || item.title;
-    delete item.short_title;
+    node.title = node.short_title || node.title;
+    delete node.short_title;
     // At the moment, we never actually use the 'short_description'
     // so no use including it.
-    delete item.short_description;
+    delete node.short_description;
 
     // isActive means that this node is a link to the current document
     // open means that this node or one of its children is a link to the current document

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -29,37 +29,55 @@ const TOUCHFILE = path.join(PROJECT_ROOT, "client", "src", "touchthis.js");
 const BUILD_JSON_SERVER =
   process.env.BUILD_JSON_SERVER || "http://localhost:5555";
 
-/** In the document, there's related_content and it contains keys
- * called 'mdn_url'. We need to transform them to relative links
- * that works with our router.
+/**
+ * Transform the `related_content` object for this document. For each node:
+ * - rename `mdn_url` to `uri`
+ * - use `short_title` instead of `title`, if it is available
+ * - delete `short_description`
+ * - set `isActive` for the node whose `uri` matches this document's `mdn_url`
+ * - set `open` for nodes which are active or which have an active child
+ *
  * This /mutates/ the document data.
  */
 function fixRelatedContent(document) {
-  function fixBlock(block) {
-    if (block.content) {
-      block.content.forEach(item => {
-        if (item.mdn_url) {
-          // always expect this to be a relative URL
-          if (!item.mdn_url.startsWith("/")) {
-            throw new Error(
-              `Document's .mdn_url doesn't start with / (${item.mdn_url})`
-            );
-          }
-          // Complicated way to rename an object key.
-          item.uri = item.mdn_url;
-          delete item.mdn_url;
+  function fixBlock(node) {
+    if (node.mdn_url) {
+      // always expect this to be a relative URL
+      if (!node.mdn_url.startsWith("/")) {
+        throw new Error(
+          `Document's .mdn_url doesn't start with / (${item.mdn_url})`
+        );
+      }
+      // Complicated way to rename an object key.
+      node.uri = node.mdn_url;
+      delete node.mdn_url;
+    }
+
+    // The sidebar only needs a 'title' and doesn't really care if
+    // it came from the full title or the 'short_title'.
+    item.title = item.short_title || item.title;
+    delete item.short_title;
+    // At the moment, we never actually use the 'short_description'
+    // so no use including it.
+    delete item.short_description;
+
+    // isActive means that this node is a link to the current document
+    // open means that this node or one of its children is a link to the current document
+    if (node.uri === document.mdn_url) {
+      node.open = true;
+      node.isActive = true;
+    }
+
+    if (node.content) {
+      for (const child of node.content) {
+        fixBlock(child);
+        if (child.open) {
+          node.open = true;
         }
-        // The sidebar only needs a 'title' and doesn't really care if
-        // it came from the full title or the 'short_title'.
-        item.title = item.short_title || item.title;
-        delete item.short_title;
-        // At the moment, we never actually use the 'short_description'
-        // so no use including it.
-        delete item.short_description;
-        fixBlock(item);
-      });
+      }
     }
   }
+
   if (document.related_content) {
     document.related_content.forEach(block => {
       fixBlock(block);


### PR DESCRIPTION
This updates the renderer so it can render the JS sidebar discussed in https://github.com/mdn/stumptown-content/issues/302 and implemented on the content side in https://github.com/mdn/stumptown-content/pull/313.

Changes:

* tell stumptown-renderer what to do about `class_constructor` ingredients. This is not related to the sidebar change itself, but is needed for us to render JS class pages at all.

* update the sidebar rendering code. Before this change it expect a sidebar to contain only three levels. But the JS sidebar can and does include more levels than that, so this change should support arbitrary levels. Of course nesting too deep would make the sidebar unusable, but I think the author of the sidebar should have the responsibility of avoiding that.

* update the sidebar styling: make it sticky and scrollable. We don't really need this but I think it is much better like this. This sidebar can get quite long, and having to scroll the page to scroll the sidebar seems broken. Note that the Azure docs, which we're partly using as a model for this, does the same: https://docs.microsoft.com/en-us/cli/azure/cdn/custom-domain?view=azure-cli-latest, as does w3schools.

* update to the latest stumptown-content

I'd like to scroll the sidebar to the section containing the current page, but I'm not sure where to put that code in the renderer. I'd be very happy to get a pointer for that, but I'd also be OK to do this in a follow up.