### PR TITLE
Render status banners

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -5,6 +5,7 @@ import { NoMatch } from "./routing";
 
 // Ingredients
 import { Prose, ProseWithHeading } from "./ingredients/prose";
+import { StatusBanners } from "./ingredients/status-banners";
 import { InteractiveExample } from "./ingredients/interactive-example";
 import { Attributes } from "./ingredients/attributes";
 import { Examples } from "./ingredients/examples";
@@ -183,6 +184,8 @@ function RenderDocumentBody({ doc }) {
           />
         );
       }
+    } else if (section.type === "status") {
+      return <StatusBanners key={`status${i}`} status={section.value} />;
     } else if (section.type === "interactive_example") {
       return (
         <InteractiveExample

--- a/client/src/ingredients/status-banners.js
+++ b/client/src/ingredients/status-banners.js
@@ -1,0 +1,42 @@
+import React from "react";
+
+const banners = {
+  deprecated: {
+    class: "deprecated-banner",
+    text:
+      "This is an <strong>deprecated</strong> technology. Avoid using it, and update existing code if possible. Be aware that this feature may cease to work at any time."
+  },
+  experimental: {
+    class: "experimental-banner",
+    text:
+      "This is an <strong>experimental</strong> technology. Check the Browser compatibility table carefully before using it in production."
+  },
+  non_standard: {
+    class: "nonstandard-banner",
+    text:
+      "This is an <strong>non-standard</strong> technology. Do not use it on production sites facing the Web: it will not work for every user."
+  }
+};
+
+function StatusBanner({ content }) {
+  return (
+    <div
+      className={`banner ${content.class}`}
+      dangerouslySetInnerHTML={{ __html: content.text }}
+    />
+  );
+}
+
+export function StatusBanners({ status }) {
+  return (
+    <>
+      {status.deprecated && <StatusBanner content={banners["deprecated"]} />}
+      {status.experimental && (
+        <StatusBanner content={banners["experimental"]} />
+      )}
+      {status.non_standard && (
+        <StatusBanner content={banners["non_standard"]} />
+      )}
+    </>
+  );
+}

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -152,7 +152,8 @@ div.content {
   ul,
   ol,
   pre,
-  .live-sample-frame {
+  .live-sample-frame,
+  .banner {
     max-width: 42rem;
   }
 
@@ -166,6 +167,23 @@ div.content {
     h2 {
       border-bottom: 1px solid #eaecef;
     }
+  }
+
+  .banner {
+    padding: 1rem;
+    margin: 0.5rem;
+  }
+
+  .deprecated-banner {
+    background-color: #ffe7e8;
+  }
+
+  .experimental-banner {
+    background-color: #fff3d4;
+  }
+
+  .nonstandard-banner {
+    background-color: #ffe7e8;
   }
 }
 


### PR DESCRIPTION
This adds support for rendering status banners, like "experimental" or "non-standard".

It's the renderer half of https://github.com/mdn/stumptown-content/pull/354 and currently requires you to build against the "support-banners" branch of https://github.com/wbamberg/stumptown-experiment/.

So we can visually check the rendered banners, I added a fake JS class "TestBanners", which borrows the compat data from [`Intl.ListFormat`](https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat), so it gets tagged "experimental". I've given it a constructor `TestBanners()` which also uses that compat data, but additionally is marked "non-standard", so we can see what multiple banners are like.

I've had to give them the `Array` URL, because one of the CI checks requires that `mdn_url` is a real MDN page.

So you should be able to see one banner at: http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array and two banners at: http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array.

