### PR TITLE
384 localized parents that are archive redirects not be exported

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -233,11 +233,16 @@ cli
     return runMakePopularitiesFile(args.csvfile, options, logger);
   });
 
-cli.parse(process.argv).then(r => {
-  // If the command explicitly returned a number, use that as the exit code
-  // Otherwise, if it's anything truthy return 1 or all else 0.
-  process.exitCode = typeof r === Number ? r : r ? 1 : 0;
-});
+cli
+  .parse(process.argv)
+  .then(r => {
+    // If the command explicitly returned a number, use that as the exit code
+    // Otherwise, if it's anything truthy return 1 or all else 0.
+    process.exitCode = typeof r === Number ? r : r ? 1 : 0;
+  })
+  .catch(err => {
+    console.log("AN ERROR HAPPENED HERE");
+  });
 
 function equalArray(a, b) {
   return a.length === b.length && a.every((x, i) => x === b[i]);

--- a/content/index.js
+++ b/content/index.js
@@ -233,16 +233,11 @@ cli
     return runMakePopularitiesFile(args.csvfile, options, logger);
   });
 
-cli
-  .parse(process.argv)
-  .then(r => {
-    // If the command explicitly returned a number, use that as the exit code
-    // Otherwise, if it's anything truthy return 1 or all else 0.
-    process.exitCode = typeof r === Number ? r : r ? 1 : 0;
-  })
-  .catch(err => {
-    console.log("AN ERROR HAPPENED HERE");
-  });
+cli.parse(process.argv).then(r => {
+  // If the command explicitly returned a number, use that as the exit code
+  // Otherwise, if it's anything truthy return 1 or all else 0.
+  process.exitCode = typeof r === Number ? r : r ? 1 : 0;
+});
 
 function equalArray(a, b) {
   return a.length === b.length && a.every((x, i) => x === b[i]);

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -422,7 +422,6 @@ async function processDocument(
           // is not one of those with /docs/ in it.
           // Like `/en-US/Firefox_OS/Developing_Firefox_OS` for example.
           // Just bail on these.
-          console.log("BUSTED:", localeRedirects[doc.parent_slug]);
           return false;
         }
         meta.translation_of = newParentSlug;

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -408,6 +408,7 @@ async function processDocument(
           // is not one of those with /docs/ in it.
           // Like `/en-US/Firefox_OS/Developing_Firefox_OS` for example.
           // Just bail on these.
+          console.log("BUSTED:", localeRedirects[doc.parent_slug]);
           return false;
         }
         meta.translation_of = newParentSlug;


### PR DESCRIPTION
Fixes #384
Fixes #404 

This builds on top of https://github.com/mdn/stumptown-renderer/pull/397
Because I couldn't wait. 

Basically, the idea is that we order ALL the documents so that those that are `is_redirect` are always processed first. Then, as we go through the `!is_redirect` and we encounter a `doc.parent_is_redirect` then we can deal with that. 

I put in some temporary console logging on these new paths. 
There were 224 documents (non-en-US) that had a `doc.parent` that was a redirect that has a legitimate new slug but whose slug is considered archived. So 224 less non-en-US docs. 
Also, there were 30 documents that are a bit more cryptic. They link to URLs that don't have `/docs/` in them. For example, there are lines like this in the `en-US/_redirects.txt` file:
```
/en-US/docs/Learn/HTML/Howto/Mark_abbreviations_and_make_them_understandable    /en-US/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting#Abbreviations
```
first of all, what's with the anchor on that?
Second of all, that redirect ought to be to `/en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting` instead. 
So I think I need to take a break and go and fix that in the general code that figures out the redirects. 
