### PR TITLE
Split slugs on slashes instead of OS path separators

### DIFF
--- a/content/scripts/utils.js
+++ b/content/scripts/utils.js
@@ -14,7 +14,7 @@ function slugToFoldername(slug) {
       .replace(/\?/g, "_question_")
 
       .toLowerCase()
-      .split(path.sep)
+      .split("/")
       .map(sanitizeFilename)
       .join(path.sep)
   );


### PR DESCRIPTION
Missed that when I reviewed it originally 🙈 

The slashes in the slug DB columns are always forward. Whereas `path.sep` is backwards on Windows, which is why I ended up with basically no hierarchy in my content fs.

I think we should just always split on forward slashes, so here's that change.