### PR TITLE
cleanups

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 Dockerfile
 Makefile
 Procfile
+content/_all-titles.json
 # exclude these directories
 /stumptown/
 /client/build/
@@ -11,9 +12,12 @@ Procfile
 /node_modules/
 /server/node_modules/
 /client/node_modules/
+/content/node_modules/
 /cli/node_modules/
 /deployment/node_modules/
 /client/src/water.css/
+/archivecontent/
+/content/files/
 
-# Mist files to ignore
+# Misc files to ignore
 /client/src/serviceWorker.js

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -53,10 +53,6 @@ function getCurrentGitBranch(fallback = "master") {
   return _currentGitBranch;
 }
 
-function isWatchmanSupported() {
-  return !childProcess.spawnSync("watchman").error;
-}
-
 // XXX is this the best way??
 function isTTY() {
   return !!process.stdout.columns;
@@ -180,24 +176,9 @@ function runBuild(sources, options, logger) {
       return builder.start();
     }
     if (options.watch || options.buildAndWatch) {
-      const supported = isWatchmanSupported();
-      if (supported) {
-        logger.debug("Watchman supposedly supported.");
-        builder.watch();
-        console.log("Starting WebSocket (port 8080) to report on builds.");
-        webSocketServer = new WebSocket.Server({ port: 8080 });
-      } else {
-        // @Gregoor Here's where we'd need a nice banner
-        logger.warn(
-          chalk.red(
-            "\nWarning! You don't have 'watchman' installed.\n" +
-              "Without 'watchman' you can't monitor large directories for " +
-              "file changes.\n" +
-              "Go to https://facebook.github.io/watchman/docs/install.html\n" +
-              "\n"
-          )
-        );
-      }
+      builder.watch();
+      console.log("Starting WebSocket (port 8080) to report on builds.");
+      webSocketServer = new WebSocket.Server({ port: 8080 });
     }
   }
 }


### PR DESCRIPTION
Ideally, you should be using `prettier` on every save in your IDE but we still use `yarn prettier-check` in `ci-lint.sh`. Also, many many days ago I switched from `watchman` (through `sane`) to `chokadir` so the check for the `watchman` daemon is no longer necessary. 