### PR TITLE
Redirects don't work in local development

### DIFF
--- a/client/src/document.js
+++ b/client/src/document.js
@@ -60,6 +60,11 @@ export class Document extends React.Component {
         console.warn(response);
         return this.setState({ loading: false, loadingError: response });
       } else {
+        if (response.redirected) {
+          // Fetching that data required a redirect!
+          // XXX perhaps do a route redirect here in React?
+          console.warn(`${url} was redirected to ${response.url}`);
+        }
         const data = await response.json();
         document.title = data.doc.title;
         this.setState({ doc: data.doc, loading: false });

--- a/server/index.js
+++ b/server/index.js
@@ -44,10 +44,11 @@ const _allRedirects = new Map();
 
 // Return the redirect but if it can't be found, just return `undefined`
 function getRedirectUrl(uri) {
-  if (!_allRedirects.size) {
+  if (!_allRedirects.size && process.env.BUILD_ROOT) {
+    const contentRoot = normalizeContentPath(process.env.BUILD_ROOT);
     // They're all in 1 level deep from CONTENT_ROOT
-    fs.readdirSync(CONTENT_ROOT)
-      .map((n) => path.join(CONTENT_ROOT, n))
+    fs.readdirSync(contentRoot)
+      .map((n) => path.join(contentRoot, n))
       .filter((filepath) => fs.statSync(filepath).isDirectory())
       .forEach((directory) => {
         fs.readdirSync(directory)
@@ -147,7 +148,7 @@ app.get("/*", async (req, res) => {
   } else if (req.url.endsWith(".json") && req.url.includes("/docs/")) {
     const redirectUrl = getRedirectUrl(req.url.replace(/\/index\.json$/, ""));
     if (redirectUrl) {
-      return res.redirect(301, redirectUrl + ".json");
+      return res.redirect(301, redirectUrl + "/index.json");
     }
 
     const specificFolder = normalizeContentPath(


### PR DESCRIPTION
Fixes #450

@Gregoor @escattone I'm pretty sure this change is sane. It's easy to test. 
That whole `getRedirectUrl()` function is pretty ugly anyway and I might refactor it into the builder instead of having it exclusively in the `server`. 
Review if you have the headspace. 