### PR TITLE
invalidate _all-titles.json

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -741,7 +741,10 @@ class Builder {
         const sitemapXml = makeSitemapXML(
           Object.entries(data)
             .filter(([uri, documentData]) => {
-              return !documentData.excludeInSitemaps;
+              // We're looping over all the keys in this.allTitles but
+              // nestled into it is also some custom keys that need
+              // to be ignored.
+              return !documentData.excludeInSitemaps && uri !== "_hash";
             })
             .map(([uri, documentData]) => {
               if (!documentData.modified) {
@@ -769,7 +772,7 @@ class Builder {
       const titles = {};
       Object.entries(data)
         .filter(([uri, documentData]) => {
-          return !documentData.excludeInTitlesJson;
+          return !documentData.excludeInTitlesJson && uri !== "_hash";
         })
         .forEach(([uri, documentData]) => {
           // This is the data that gets put into each 'titles.json` file which


### PR DESCRIPTION
Fixes #466

I like this solution because it's brutally simple. If a single dependency package has changed since you last started `yari`, it means that saved `content/_all-titles.json` file is considered out-of-date. But this is the worst-case scenario. Any other more important change that can have an effect on `this.allTitles` should immediately be considered. In that case, the worst case is you have to wait a bunch of seconds. 

Good caching is one that is predictable and tightly controlled. It's better than aggressive and potentially confusing caching. 

Also, this new strategy matches exactly how the caching works on building the `index.html` (and `index.json`) files. So now they are treated exactly the same. If you don't touch and `.js` files and re-start the Node programs, the caching works in your favor. 