### PR TITLE
already rendered archive content

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -984,7 +984,7 @@ class Builder {
 
     let renderedHtml;
 
-    // When the source has this set to truthy it simple means, the 'index.html'
+    // When 'source.htmlAlreadyRendered' is true, it simply means that the 'index.html'
     // is already fully rendered HTML.
     if (source.htmlAlreadyRendered) {
       renderedHtml = rawHtml;

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -989,11 +989,10 @@ class Builder {
     if (source.htmlAlreadyRendered) {
       renderedHtml = rawHtml;
     } else {
-      const renderingResult = await this.renderHtml(rawHtml, metadata);
-      renderedHtml = renderingResult[0];
       // XXX The this.renderHtml() method actually returns a tuple
       // of (renderedHtml, errors) but we're not doing anything with the
-      // errors yet.
+      // errors yet. Which we *will* do eventually.
+      [renderedHtml] = await this.renderHtml(rawHtml, metadata);
     }
 
     // Now we've read in all the "inputs" needed.

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -71,14 +71,7 @@ async function populateRedirectInfo(pool, constraintsSQL, queryArgs) {
     // archive, as well as the map that provides the final
     // destination of each redirect that we'll keep.
     const isInfiniteLoop = chainOfRedirects.has(toUri);
-    if (isInfiniteLoop) {
-      // // This next URI in the redirect chain is already in
-      // // the chain, so we've discovered an infinite loop.
-      // const arrayOfRedirects = [...chainOfRedirects];
-      // arrayOfRedirects.push(toUri);
-      // const chainAsString = arrayOfRedirects.join(" --> ");
-      // // console.error(`FOUND INFINITE REDIRECT LOOP: ${chainAsString}`);
-    } else {
+    if (!isInfiniteLoop) {
       const nextUri = redirects.get(toUri);
       if (nextUri) {
         return extractFromChain(nextUri, chainOfRedirects.add(toUri));

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -72,12 +72,12 @@ async function populateRedirectInfo(pool, constraintsSQL, queryArgs) {
     // destination of each redirect that we'll keep.
     const isInfiniteLoop = chainOfRedirects.has(toUri);
     if (isInfiniteLoop) {
-      // This next URI in the redirect chain is already in
-      // the chain, so we've discovered an infinite loop.
-      const arrayOfRedirects = [...chainOfRedirects];
-      arrayOfRedirects.push(toUri);
-      const chainAsString = arrayOfRedirects.join(" --> ");
-      // console.error(`FOUND INFINITE REDIRECT LOOP: ${chainAsString}`);
+      // // This next URI in the redirect chain is already in
+      // // the chain, so we've discovered an infinite loop.
+      // const arrayOfRedirects = [...chainOfRedirects];
+      // arrayOfRedirects.push(toUri);
+      // const chainAsString = arrayOfRedirects.join(" --> ");
+      // // console.error(`FOUND INFINITE REDIRECT LOOP: ${chainAsString}`);
     } else {
       const nextUri = redirects.get(toUri);
       if (nextUri) {
@@ -520,7 +520,11 @@ async function processDocument(
   await fs.promises.mkdir(folder, { recursive: true });
   const htmlFile = path.join(folder, "index.html");
 
-  await fs.promises.writeFile(htmlFile, doc.html);
+  if (isArchive) {
+    await fs.promises.writeFile(htmlFile, doc.rendered_html);
+  } else {
+    await fs.promises.writeFile(htmlFile, doc.html);
+  }
 
   const wikiHistoryFile = path.join(folder, "wikihistory.json");
   const metaFile = path.join(folder, "index.yaml");


### PR DESCRIPTION
Here's how I tested it...

First I made sure I had this in my `.env` file:
```
BUILD_ROOT=content/files
BUILD_ARCHIVE_ROOT=archivecontent/files
```
Then I ran `node content import --start-clean`
Check the contents of `archivecontent/files/de/codeschnipsel/index.html` and `content/files/en-us/games/anatomy/index.html`
Then `yarn clean && yarn prebuild` 
Then `node content build -l de --no-progressbar` (because I didn't want to wait for en-US)
Start the file server `nf start`
and then lastly visit http://localhost:5000/de/docs/DragDrop/Drag_and_Drop/ and http://localhost:5000/de/docs/Codeschnipsel/
(fun fact, note that the language switcheroo works fine for the built archive content too!)