### PR TITLE
React router v6

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,6 @@
   "license": "MPL-2.0",
   "main": "build/app.js",
   "dependencies": {
-    "@reach/router": "1.3.3",
     "cross-env": "^7.0.2",
     "flexsearch": "0.6.32",
     "fuzzysearch": "1.0.3",
@@ -14,6 +13,8 @@
     "prismjs": "1.20.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-router": "6.0.0-alpha.3",
+    "react-router-dom": "6.0.0-alpha.3",
     "react-scripts": "3.4.1",
     "sockette": "2.0.6",
     "typeface-zilla-slab": "0.0.72"

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Router, Link } from "@reach/router";
+import { Routes, Route, Link, useNavigate } from "react-router-dom";
 
 import { Homepage } from "./homepage";
 import { Document } from "./document";
@@ -9,27 +9,33 @@ import { SearchWidget } from "./search";
 export function App(appProps) {
   return (
     <div>
-      <Router primary={false}>
-        <Header default />
-      </Router>
+      <Header />
+
       <section className="section">
-        <Router>
-          <Homepage path="/" />
-          <Document {...appProps} path="/:locale/docs/*" />
-          <NoMatch default />
-        </Router>
+        <Routes>
+          {/* Consider using useRoutes() hook instead! */}
+          <Route path="/" element={<Homepage />} />
+          <Route path="/:locale/docs/*" element={<Document />} />
+          <Route path="*" element={<NoMatch />} />
+        </Routes>
       </section>
     </div>
   );
 }
 
-function Header({ location }) {
+function Header() {
+  const navigate = useNavigate();
   return (
     <header>
       <h1>
         <Link to="/">MDN Web Docs</Link>
       </h1>
-      <SearchWidget pathname={location.pathname} />
+      <SearchWidget
+        onRedirect={(uri) => {
+          console.log("Let's navigate to:", uri);
+          navigate(uri);
+        }}
+      />
     </header>
   );
 }

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -24,18 +24,11 @@ export function App(appProps) {
 }
 
 function Header() {
-  // const navigate = useNavigate();
   return (
     <header>
       <h1>
         <Link to="/">MDN Web Docs</Link>
       </h1>
-      {/* <SearchWidget
-        onRedirect={(uri) => {
-          console.log("Let's navigate to:", uri);
-          navigate(uri);
-        }}
-      /> */}
       <SearchWidget />
     </header>
   );

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route, Link, useNavigate } from "react-router-dom";
+import { Routes, Route, Link } from "react-router-dom";
 
 import { Homepage } from "./homepage";
 import { Document } from "./document";
@@ -24,18 +24,19 @@ export function App(appProps) {
 }
 
 function Header() {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   return (
     <header>
       <h1>
         <Link to="/">MDN Web Docs</Link>
       </h1>
-      <SearchWidget
+      {/* <SearchWidget
         onRedirect={(uri) => {
           console.log("Let's navigate to:", uri);
           navigate(uri);
         }}
-      />
+      /> */}
+      <SearchWidget />
     </header>
   );
 }

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -15,7 +15,7 @@ export function App(appProps) {
         <Routes>
           {/* Consider using useRoutes() hook instead! */}
           <Route path="/" element={<Homepage />} />
-          <Route path="/:locale/docs/*" element={<Document />} />
+          <Route path="/:locale/docs/*" element={<Document {...appProps} />} />
           <Route path="*" element={<NoMatch />} />
         </Routes>
       </section>

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -13,7 +13,6 @@ export function App(appProps) {
 
       <section className="section">
         <Routes>
-          {/* Consider using useRoutes() hook instead! */}
           <Route path="/" element={<Homepage />} />
           <Route path="/:locale/docs/*" element={<Document {...appProps} />} />
           <Route path="*" element={<NoMatch />} />

--- a/client/src/app.test.js
+++ b/client/src/app.test.js
@@ -1,10 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { MemoryRouter } from "react-router-dom";
 
 import { App } from "./app";
 
 it("renders without crashing", () => {
-  const app = <App />;
+  const app = (
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
   const div = document.createElement("div");
   ReactDOM.render(app, div);
   ReactDOM.unmountComponentAtNode(div);

--- a/client/src/document/index.js
+++ b/client/src/document/index.js
@@ -80,7 +80,7 @@ export function Document(props) {
     }
   }, [getCurrentDocumentUri]);
 
-  // There are 2 reasons why you'd want to call fetchDocument() on mounts:
+  // There are 2 reasons why you'd want to call fetchDocument():
   // - The slug/locale combo has *changed*
   // - The page started with no props.doc
   useEffect(() => {

--- a/client/src/document/index.js
+++ b/client/src/document/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 
 import { NoMatch } from "../routing";
 
@@ -19,6 +19,7 @@ import { DocumentSpy } from "./spy";
 
 export class Document extends React.Component {
   state = {
+    // XXX this kinda stinks, to copy from props to state.
     doc: this.props.doc || null,
     loading: false,
     notFound: false,
@@ -26,6 +27,7 @@ export class Document extends React.Component {
   };
 
   componentDidMount() {
+    console.log("MOUNTED:", this.props);
     if (!this.state.doc) {
       this.fetchDocument();
     }
@@ -36,6 +38,7 @@ export class Document extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    console.log(this.props, prevProps);
     if (
       this.props["*"] !== prevProps["*"] ||
       this.props.locale !== prevProps.locale

--- a/client/src/document/index.js
+++ b/client/src/document/index.js
@@ -22,7 +22,6 @@ export function Document(props) {
 
   const p = useParams();
   const newProps = Object.assign({}, props, p);
-  console.log(Object.keys(newProps));
   return <DocumentInner {...newProps} />;
 }
 

--- a/client/src/document/index.js
+++ b/client/src/document/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 import { NoMatch } from "../routing";
 
@@ -17,9 +17,17 @@ import { DocumentTranslations } from "./languages";
 import { EditThisPage } from "./editthispage";
 import { DocumentSpy } from "./spy";
 
-export class Document extends React.Component {
+export function Document(props) {
+  // LOG
+
+  const p = useParams();
+  const newProps = Object.assign({}, props, p);
+  console.log(Object.keys(newProps));
+  return <DocumentInner {...newProps} />;
+}
+
+class DocumentInner extends React.Component {
   state = {
-    // XXX this kinda stinks, to copy from props to state.
     doc: this.props.doc || null,
     loading: false,
     notFound: false,
@@ -27,7 +35,6 @@ export class Document extends React.Component {
   };
 
   componentDidMount() {
-    console.log("MOUNTED:", this.props);
     if (!this.state.doc) {
       this.fetchDocument();
     }
@@ -38,7 +45,6 @@ export class Document extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    console.log(this.props, prevProps);
     if (
       this.props["*"] !== prevProps["*"] ||
       this.props.locale !== prevProps.locale

--- a/client/src/document/index.js
+++ b/client/src/document/index.js
@@ -44,7 +44,7 @@ export function Document(props) {
     setLoading(false);
   }, [loadingError]);
 
-  const getCurrentPathname = useCallback(() => {
+  const getCurrentDocumentUri = useCallback(() => {
     let pathname = `/${locale}/docs/${slug}`;
     // If you're in local development Express will force the trailing /
     // on any URL. We can't keep that if we're going to compare the current
@@ -56,7 +56,7 @@ export function Document(props) {
   }, [slug, locale]);
 
   const fetchDocument = useCallback(async () => {
-    let url = getCurrentPathname();
+    let url = getCurrentDocumentUri();
     url += "/index.json";
     console.log("OPENING", url);
     let response;
@@ -78,34 +78,7 @@ export function Document(props) {
       const data = await response.json();
       setDoc(data.doc);
     }
-  }, [getCurrentPathname]);
-  // async function fetchDocument() {
-  //   let url = `/${locale}/docs/${slug}`;
-  //   if (!url.endsWith("/")) {
-  //     url += "/";
-  //   }
-  //   url += "index.json";
-  //   console.log("OPENING", url);
-  //   let response;
-  //   try {
-  //     response = await fetch(url);
-  //   } catch (ex) {
-  //     setLoadingError(ex);
-  //     return;
-  //   }
-  //   if (!response.ok) {
-  //     console.warn(response);
-  //     setLoadingError(response);
-  //   } else {
-  //     if (response.redirected) {
-  //       // Fetching that data required a redirect!
-  //       // XXX perhaps do a route redirect here in React?
-  //       console.warn(`${url} was redirected to ${response.url}`);
-  //     }
-  //     const data = await response.json();
-  //     setDoc(data.doc);
-  //   }
-  // }
+  }, [getCurrentDocumentUri]);
 
   // There are 2 reasons why you'd want to call fetchDocument() on mounts:
   // - The slug/locale combo has *changed*
@@ -113,15 +86,15 @@ export function Document(props) {
   useEffect(() => {
     if (
       !props.doc ||
-      getCurrentPathname().toLowerCase() !== props.doc.mdn_url.toLowerCase()
+      getCurrentDocumentUri().toLowerCase() !== props.doc.mdn_url.toLowerCase()
     ) {
       setLoading(true);
       fetchDocument();
     }
-  }, [slug, locale, props.doc, getCurrentPathname, fetchDocument]);
+  }, [slug, locale, props.doc, getCurrentDocumentUri, fetchDocument]);
 
   function onMessage(data) {
-    if (data.documentUri === getCurrentPathname()) {
+    if (data.documentUri === getCurrentDocumentUri()) {
       // The recently edited document is the one we're currently looking at!
       fetchDocument();
     }

--- a/client/src/document/ingredients/browser-compatibility-table/error-boundary.test.js
+++ b/client/src/document/ingredients/browser-compatibility-table/error-boundary.test.js
@@ -1,9 +1,15 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
 import { BrowserCompatibilityErrorBoundary } from "./error-boundary.js";
 
+function renderWithRouter(component) {
+  return render(<MemoryRouter>{component}</MemoryRouter>);
+}
+
 it("renders without crashing", () => {
-  const { container } = render(
+  const { container } = renderWithRouter(
     <BrowserCompatibilityErrorBoundary>
       <div />
     </BrowserCompatibilityErrorBoundary>
@@ -27,7 +33,7 @@ it("renders crashing mock component", () => {
     );
   };
 
-  const { container } = render(
+  const { container } = renderWithRouter(
     <BrowserCompatibilityErrorBoundary>
       <CrashingComponent />
     </BrowserCompatibilityErrorBoundary>

--- a/client/src/document/ingredients/browser-compatibility-table/index.test.js
+++ b/client/src/document/ingredients/browser-compatibility-table/index.test.js
@@ -9,8 +9,7 @@ function renderWithRouter(component) {
 }
 
 it("renders error boundary when no data is present", () => {
-  const { container } = renderWithRouter(<BrowserCompatibilityTable />);
-  expect(container.querySelector(".bc-table")).toBeNull();
-  expect(container.querySelector(".bc-table-error-boundary")).toBeDefined();
+  const { getByText } = renderWithRouter(<BrowserCompatibilityTable />);
+  expect(getByText(/this table has encountered unhandled error/));
   // TODO: When `BrowserCompatibilityErrorBoundary` reports to Sentry, spy on the report function so that we can assert the error stack
 });

--- a/client/src/document/ingredients/browser-compatibility-table/index.test.js
+++ b/client/src/document/ingredients/browser-compatibility-table/index.test.js
@@ -1,9 +1,15 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
 import { BrowserCompatibilityTable } from "./index.js";
 
+function renderWithRouter(component) {
+  return render(<MemoryRouter>{component}</MemoryRouter>);
+}
+
 it("renders error boundary when no data is present", () => {
-  const { container } = render(<BrowserCompatibilityTable />);
+  const { container } = renderWithRouter(<BrowserCompatibilityTable />);
   expect(container.querySelector(".bc-table")).toBeNull();
   expect(container.querySelector(".bc-table-error-boundary")).toBeDefined();
   // TODO: When `BrowserCompatibilityErrorBoundary` reports to Sentry, spy on the report function so that we can assert the error stack

--- a/client/src/document/ingredients/browser-compatibility-table/rows.js
+++ b/client/src/document/ingredients/browser-compatibility-table/rows.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 import { BrowserSupportDetail } from "./browser-support-detail";
 import { BrowserSupportNotes } from "./browser-support-notes";
 

--- a/client/src/document/ingredients/link-lists.js
+++ b/client/src/document/ingredients/link-lists.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 
 export function LinkList({ title, links }) {
   return (

--- a/client/src/document/languages.js
+++ b/client/src/document/languages.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 
 import "./languages.css";
 

--- a/client/src/document/spy.js
+++ b/client/src/document/spy.js
@@ -3,7 +3,7 @@
  */
 import React, { useState, useEffect, useRef } from "react";
 import Sockette from "sockette";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 
 import "./spy.css";
 

--- a/client/src/homepage.js
+++ b/client/src/homepage.js
@@ -1,66 +1,62 @@
 import React from "react";
-import { Link } from "@reach/router";
+import { Link } from "react-router-dom";
 
-export class Homepage extends React.Component {
-  render() {
-    return (
-      <div>
-        <h2>Welcome to MDN</h2>
-        <h3>
-          HTML Elements (sample, <code>en-US</code>)
-        </h3>
-        <ul>
-          <li>
-            <Link to="/en-US/docs/Web/HTML/Element/audio">HTML/audio</Link>
-          </li>
-          <li>
-            <Link to="/en-US/docs/Web/HTML/Element/video">HTML/video</Link>
-          </li>
-          <li>
-            <Link to="/en-US/docs/Web/HTML/Element/canvas">HTML/canvas</Link>
-          </li>
-        </ul>
-        <h3>
-          HTML Elements (sample, <code>fr</code>)
-        </h3>
-        <ul>
-          <li>
-            <Link to="/fr/docs/Web/HTML/Element">HTML</Link>
-          </li>
-          <li>
-            <Link to="/fr/docs/Web/HTML/Element/abbr">HTML/abbr</Link>
-          </li>
-          <li>
-            <Link to="/fr/docs/Web/HTML/Element/video">HTML/video</Link>
-          </li>
-        </ul>
-        <h3>HTML Guide Pages</h3>
-        <ul>
-          <li>
-            <Link to="/en-US/docs/Web/HTML/Element">
-              Index of HTML elements
-            </Link>
-          </li>
-          <li>
-            <Link to="/en-US/docs/Learn/HTML/Introduction_to_HTML">
-              Introduction to HTML
-            </Link>
-          </li>
-          <li>
-            <Link to="/en-US/docs/Web/HTML/Applying_color">
-              Applying color to HTML elements using CSS
-            </Link>
-          </li>
-        </ul>
-        <h3>JavaScript Reference</h3>
-        <ul>
-          <li>
-            <Link to="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt">
-              BigInt
-            </Link>
-          </li>
-        </ul>
-      </div>
-    );
-  }
+export function Homepage() {
+  return (
+    <div>
+      <h2>Welcome to MDN</h2>
+      <h3>
+        HTML Elements (sample, <code>en-US</code>)
+      </h3>
+      <ul>
+        <li>
+          <Link to="/en-US/docs/Web/HTML/Element/audio">HTML/audio</Link>
+        </li>
+        <li>
+          <Link to="/en-US/docs/Web/HTML/Element/video">HTML/video</Link>
+        </li>
+        <li>
+          <Link to="/en-US/docs/Web/HTML/Element/canvas">HTML/canvas</Link>
+        </li>
+      </ul>
+      <h3>
+        HTML Elements (sample, <code>fr</code>)
+      </h3>
+      <ul>
+        <li>
+          <Link to="/fr/docs/Web/HTML/Element">HTML</Link>
+        </li>
+        <li>
+          <Link to="/fr/docs/Web/HTML/Element/abbr">HTML/abbr</Link>
+        </li>
+        <li>
+          <Link to="/fr/docs/Web/HTML/Element/video">HTML/video</Link>
+        </li>
+      </ul>
+      <h3>HTML Guide Pages</h3>
+      <ul>
+        <li>
+          <Link to="/en-US/docs/Web/HTML/Element">Index of HTML elements</Link>
+        </li>
+        <li>
+          <Link to="/en-US/docs/Learn/HTML/Introduction_to_HTML">
+            Introduction to HTML
+          </Link>
+        </li>
+        <li>
+          <Link to="/en-US/docs/Web/HTML/Applying_color">
+            Applying color to HTML elements using CSS
+          </Link>
+        </li>
+      </ul>
+      <h3>JavaScript Reference</h3>
+      <ul>
+        <li>
+          <Link to="/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt">
+            BigInt
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import "./index.scss";
 import "typeface-zilla-slab";
 import { App } from "./app";
@@ -13,7 +14,9 @@ if (documentDataElement) {
 }
 const app = (
   <React.StrictMode>
-    <App doc={docData} />
+    <Router>
+      <App doc={docData} />
+    </Router>
   </React.StrictMode>
 );
 if (container.firstElementChild) {

--- a/client/src/routing.js
+++ b/client/src/routing.js
@@ -1,6 +1,9 @@
 import React from "react";
 
-export function NoMatch({ location, message = null }) {
+export function NoMatch(props) {
+  console.log(props);
+  const message = "";
+  const location = { pathname: "fff" };
   return (
     <div>
       <h3>Page Not Found</h3>

--- a/client/src/routing.js
+++ b/client/src/routing.js
@@ -1,14 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
 
-export function NoMatch(props) {
-  console.log(props);
+export function NoMatch() {
+  const pathname = useParams()["*"];
   const message = "";
-  const location = { pathname: "fff" };
+  useEffect(() => {
+    document.title = "Page Not Found";
+  });
   return (
     <div>
       <h3>Page Not Found</h3>
+      <p>{message ? message : `Sorry, no document for ${pathname}.`}</p>
       <p>
-        {message ? message : `Sorry, no document for ${location.pathname}.`}
+        <Link to="/">Go back to the home page</Link>
       </p>
     </div>
   );

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -1,6 +1,6 @@
-import { Redirect } from "@reach/router";
+import { useNavigate } from "react-router-dom";
 import FlexSearch from "flexsearch";
-import React from "react";
+import React, { useEffect } from "react";
 import FuzzySearch from "./fuzzy-search";
 import "./search.scss";
 
@@ -22,7 +22,7 @@ export class SearchWidget extends React.Component {
     initializing: false,
     lastQ: "",
     q: "",
-    redirectTo: null,
+    // redirectTo: null,
     searchResults: [],
     serverError: null,
     showSearchResults: true,
@@ -62,7 +62,7 @@ export class SearchWidget extends React.Component {
           highlitResult: null,
           lastQ: "",
           q: "",
-          redirectTo: null,
+          // redirectTo: null,
           showSearchResults: false,
           locale: this.props.pathname.split("/")[1] || "en-US",
         });
@@ -341,23 +341,26 @@ export class SearchWidget extends React.Component {
 
   submitHandler = (event) => {
     event.preventDefault();
+    const { onRedirect } = this.props;
     const { highlitResult, searchResults } = this.state;
-    let redirectTo;
+    // let redirectTo;
     if (searchResults.length === 1) {
-      redirectTo = searchResults[0].uri;
+      onRedirect(searchResults[0].uri);
     } else if (searchResults.length && highlitResult !== null) {
-      redirectTo = searchResults[highlitResult].uri;
+      onRedirect(searchResults[highlitResult].uri);
     } else {
       return;
     }
     this.setState({
-      redirectTo,
+      // redirectTo,
       showSearchResults: false,
     });
   };
 
   redirect = (uri) => {
-    this.setState({ redirectTo: uri });
+    const { onRedirect } = this.props;
+    onRedirect(uri);
+    // this.setState({ redirectTo: uri });
   };
 
   // computeBackgroundQ = (caseInsensitive = false) => {
@@ -395,14 +398,17 @@ export class SearchWidget extends React.Component {
     const {
       highlitResult,
       q,
-      redirectTo,
+      // redirectTo,
       searchResults,
       serverError,
       showSearchResults,
     } = this.state;
-    if (redirectTo) {
-      return <Redirect noThrow replace={false} to={redirectTo} />;
-    }
+    // if (redirectTo) {
+    //   // return <Redirect noThrow replace={false} to={redirectTo} />;
+    //   this.props.onRedirect(redirectTo);
+    //   return null;
+    //   // return <RedirectHack uri={redirectTo} />;
+    // }
 
     // The fuzzy search is engaged if the search term starts with a '/'
     // and does not have any spaces in it.
@@ -468,6 +474,18 @@ export class SearchWidget extends React.Component {
       </form>
     );
   }
+}
+
+/** The SearchWidget component is a class, not a (hook) function.
+ * The only way I know to use useNavigate() is to do it in a function.
+ * Therefore, we're using this here to help the SearchWidget component.
+ */
+function RedirectHack({ uri }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(uri);
+  });
+  return null;
 }
 
 class ShowSearchResults extends React.PureComponent {

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -41,7 +41,7 @@ const INACTIVE_PLACEHOLDER = isMobileUserAgent()
 export class SearchWidgetClass extends React.Component {
   state = {
     highlitResult: null,
-    initializing: false,
+    initialized: false,
     ready: false,
     lastQ: "",
     q: "",

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -23,17 +23,19 @@ export function SearchWidget() {
     <SearchWidgetClass
       pathname={pathname}
       onRedirect={(uri) => {
-        console.log("Let's navigate to:", uri);
         navigate(uri);
       }}
     />
   );
 }
 
-class SearchWidgetClass extends React.Component {
+// TODO the only reason exporting this, for now, is to make
+// jest tests pass until https://github.com/mdn/stumptown-renderer/pull/494
+// is resolved.
+export class SearchWidgetClass extends React.Component {
   state = {
     highlitResult: null,
-    initializing: false, // XXX bad name!
+    initializing: false,
     ready: false,
     lastQ: "",
     q: "",
@@ -42,7 +44,6 @@ class SearchWidgetClass extends React.Component {
     showSearchResults: true,
   };
 
-  INITIALIZING_PLACEHOLDER = "Initializing search...";
   ACTIVE_PLACEHOLDER = "Go ahead. Type your search...";
   INACTIVE_PLACEHOLDER = isMobileUserAgent()
     ? "Site search..."
@@ -91,7 +92,6 @@ class SearchWidgetClass extends React.Component {
 
   initializeIndex = () => {
     if (this.state.initializing) {
-      console.log("Already initializing");
       return;
     }
 
@@ -136,7 +136,6 @@ class SearchWidgetClass extends React.Component {
       }
       const { titles } = await response.json();
       this.indexTitles(titles);
-      console.log("Have called indexTitles", titles);
       this.inputRef.current.placeholder = this.ACTIVE_PLACEHOLDER;
 
       // So we can keep track of how old the data is when stored
@@ -184,9 +183,7 @@ class SearchWidgetClass extends React.Component {
 
   updateSearch = () => {
     const q = this.state.q.trim();
-    console.log("IN updateSearch", { q });
     if (!this.state.ready) {
-      console.log("not ready yet!");
       return;
     }
     if (!q) {
@@ -196,7 +193,6 @@ class SearchWidgetClass extends React.Component {
     } else if (!this.index) {
       // This can happen if the initializing hasn't completed yet or
       // completed un-successfully.
-      console.log("no index!");
       return;
     } else {
       // console.log(
@@ -234,8 +230,6 @@ class SearchWidgetClass extends React.Component {
       //   window.clearTimeout(this.hideSoon);
       // }
 
-      console.log({ q });
-
       if (q.startsWith("/") && !/\s/.test(q)) {
         // Fuzzy-String search on the URI
 
@@ -257,7 +251,6 @@ class SearchWidgetClass extends React.Component {
               substrings: fuzzyResult.substrings,
             };
           });
-          console.log("RESULTS:", results);
           this.setState({
             highlitResult: results.length ? 0 : null,
             lastQ: q,

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -1,6 +1,6 @@
-import { useNavigate } from "react-router-dom";
+import React from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import FlexSearch from "flexsearch";
-import React, { useEffect } from "react";
 import FuzzySearch from "./fuzzy-search";
 import "./search.scss";
 
@@ -16,13 +16,26 @@ function isMobileUserAgent() {
   );
 }
 
-export class SearchWidget extends React.Component {
+export function SearchWidget() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  return (
+    <SearchWidgetClass
+      pathname={pathname}
+      onRedirect={(uri) => {
+        console.log("Let's navigate to:", uri);
+        navigate(uri);
+      }}
+    />
+  );
+}
+
+class SearchWidgetClass extends React.Component {
   state = {
     highlitResult: null,
     initializing: false,
     lastQ: "",
     q: "",
-    // redirectTo: null,
     searchResults: [],
     serverError: null,
     showSearchResults: true,
@@ -62,7 +75,6 @@ export class SearchWidget extends React.Component {
           highlitResult: null,
           lastQ: "",
           q: "",
-          // redirectTo: null,
           showSearchResults: false,
           locale: this.props.pathname.split("/")[1] || "en-US",
         });
@@ -343,7 +355,6 @@ export class SearchWidget extends React.Component {
     event.preventDefault();
     const { onRedirect } = this.props;
     const { highlitResult, searchResults } = this.state;
-    // let redirectTo;
     if (searchResults.length === 1) {
       onRedirect(searchResults[0].uri);
     } else if (searchResults.length && highlitResult !== null) {
@@ -352,7 +363,6 @@ export class SearchWidget extends React.Component {
       return;
     }
     this.setState({
-      // redirectTo,
       showSearchResults: false,
     });
   };
@@ -360,7 +370,6 @@ export class SearchWidget extends React.Component {
   redirect = (uri) => {
     const { onRedirect } = this.props;
     onRedirect(uri);
-    // this.setState({ redirectTo: uri });
   };
 
   // computeBackgroundQ = (caseInsensitive = false) => {
@@ -474,18 +483,6 @@ export class SearchWidget extends React.Component {
       </form>
     );
   }
-}
-
-/** The SearchWidget component is a class, not a (hook) function.
- * The only way I know to use useNavigate() is to do it in a function.
- * Therefore, we're using this here to help the SearchWidget component.
- */
-function RedirectHack({ uri }) {
-  const navigate = useNavigate();
-  useEffect(() => {
-    navigate(uri);
-  });
-  return null;
 }
 
 class ShowSearchResults extends React.PureComponent {

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -407,17 +407,10 @@ class SearchWidgetClass extends React.Component {
     const {
       highlitResult,
       q,
-      // redirectTo,
       searchResults,
       serverError,
       showSearchResults,
     } = this.state;
-    // if (redirectTo) {
-    //   // return <Redirect noThrow replace={false} to={redirectTo} />;
-    //   this.props.onRedirect(redirectTo);
-    //   return null;
-    //   // return <RedirectHack uri={redirectTo} />;
-    // }
 
     // The fuzzy search is engaged if the search term starts with a '/'
     // and does not have any spaces in it.

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -182,9 +182,6 @@ export class SearchWidgetClass extends React.Component {
 
   updateSearch = () => {
     const q = this.state.q.trim();
-    if (!this.state.ready) {
-      return;
-    }
     if (!q) {
       if (this.state.showSearchResults) {
         this.setState({ showSearchResults: false });

--- a/client/src/search.js
+++ b/client/src/search.js
@@ -41,8 +41,7 @@ const INACTIVE_PLACEHOLDER = isMobileUserAgent()
 export class SearchWidgetClass extends React.Component {
   state = {
     highlitResult: null,
-    initialized: false,
-    ready: false,
+    initialized: null, // null=not started, false=started, true=finished
     lastQ: "",
     q: "",
     searchResults: [],

--- a/client/src/search.scss
+++ b/client/src/search.scss
@@ -46,6 +46,11 @@ form.search-widget {
     color: red;
     font-size: 80%;
   }
+  p.initializing {
+    margin: 0;
+    color: #666;
+    font-size: 80;
+  }
 
   .search-results {
     position: absolute;

--- a/client/src/search.scss
+++ b/client/src/search.scss
@@ -46,11 +46,6 @@ form.search-widget {
     color: red;
     font-size: 80%;
   }
-  p.initializing {
-    margin: 0;
-    color: #666;
-    font-size: 80;
-  }
 
   .search-results {
     position: absolute;

--- a/client/src/search.test.js
+++ b/client/src/search.test.js
@@ -128,6 +128,9 @@ describe("Tests using XHR", () => {
     // main component.
     // Let's leave it until we learn more about how to test
     // with react-router v6.
+    // By the way, here's an example of how they do it within tests
+    // inside react-router-dom itself:
+    // https://github.com/ReactTraining/react-router/blob/e576ca7bf65f62680cc61b7f0ea29f0c8fd13d65/packages/react-router-dom/__tests__/navigate-encode-params-test.js#L53
     // console.log(window.location.pathname);
   });
 });

--- a/client/src/search.test.js
+++ b/client/src/search.test.js
@@ -1,11 +1,8 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-// import { createMemoryHistory } from "history";
 
 import { SearchWidget } from "./search";
-
-// const history = createMemoryHistory();
 
 function renderWithRouter(component) {
   return render(<MemoryRouter>{component}</MemoryRouter>);
@@ -118,66 +115,31 @@ describe("Tests using XHR", () => {
     expect(getByText("Fuzzy searching by URI")).toBeDefined();
   });
 
-  test("should redirect when clicking a search result", async () => {
-    // // // Define onPushState function to listen for redirect
-    // // const onPushState = (event) => {
-    // //   expect(event.detail.url).toBe("/docs/Web/HTML/Element/abbr");
-    // //   window.removeEventListener("pushState", onPushState);
-    // //   done();
-    // // };
-    // // window.addEventListener("pushState", onPushState);
-    // const { container, debug } = renderWithRouter(<SearchWidget />);
-    // const input = container.querySelector('[type="search"]');
-    // // Focus input to get titles from XHR
-    // fireEvent.focus(input);
-    // fireEvent.change(input, {
-    //   target: { value: "/dwm/mtabr" },
-    // });
-    // // Get the search results
-    // // const searchResults = await waitFor(() =>
-    // //   container.querySelector("div.search-results")
-    // // );
-    // const x = await waitFor(() => {
-    //   return container.querySelector("div.highlit");
-    // });
-    // console.log(x);
-    // debug();
-    // // console.log({ searchResults });
-
-    const { container, getByText, debug } = renderWithRouter(<SearchWidget />);
+  test("Should redirect when clicking a search result", async (done) => {
+    // Define onPushState function to listen for redirect
+    const onPushState = (event) => {
+      expect(event.detail.url).toBe("/docs/Web/HTML/Element/abbr");
+      window.removeEventListener("pushState", onPushState);
+      done();
+    };
+    window.addEventListener("pushState", onPushState);
+    const { container } = renderWithRouter(<SearchWidget pathname="/" />);
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
-    console.log("A", input.placeholder);
     fireEvent.focus(input);
-    console.log("B", input.placeholder);
-    // Before typing anything, wait for the placeholder of the input to change
-    await waitFor(() =>
-      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
-    );
-    console.log("C", input.placeholder);
     fireEvent.change(input, {
-      target: { value: "/dwm/mtabr" },
+      target: { value: "/docs/Web/HTML/Element/abbr" },
     });
     // Get the search results
     const searchResults = await waitFor(() =>
       container.querySelector("div.search-results")
     );
-    console.log("C", input.placeholder);
-    // Length of children should be 2 including the "Fuzzy searching by URI" div
-    expect(searchResults.children.length).toBe(2);
-    expect(input.classList.contains("has-search-results")).toBe(true);
-    debug();
-    expect(getByText("<abbr>: The Abbreviation element")).toBeDefined();
-    expect(getByText("Fuzzy searching by URI")).toBeDefined();
-
     const targetResult = container.querySelector("div.highlit");
-    console.log(targetResult);
-
     // Click the highlit result
     fireEvent.click(targetResult);
   });
 
-  test("should remove search-results class after clicking a result", async () => {
+  test("Should remove search-results class after clicking a result", async () => {
     const { container } = renderWithRouter(<SearchWidget pathname="/" />);
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR

--- a/client/src/search.test.js
+++ b/client/src/search.test.js
@@ -63,6 +63,9 @@ describe("Tests using XHR", () => {
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
+    await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
     expect(global.localStorage.getItem("titles")).toBeDefined();
   });
 
@@ -71,6 +74,9 @@ describe("Tests using XHR", () => {
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
+    await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
     fireEvent.change(input, { target: { value: "div" } });
     // Get the search results
     const searchResults = await waitFor(() =>
@@ -86,6 +92,9 @@ describe("Tests using XHR", () => {
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
+    await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
     fireEvent.change(input, { target: { value: "ABb" } });
     // Get the search results
     const searchResults = await waitFor(() =>
@@ -97,11 +106,15 @@ describe("Tests using XHR", () => {
   });
 
   test("should get search results by URI", async () => {
-    const { container, getByText } = renderWithRouter(<SearchWidget />);
+    const { container, getByText, debug } = renderWithRouter(<SearchWidget />);
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
+    debug();
+    console.log(
       container.querySelector('input[type="search"][placeholder^="Go ahead"]')
     );
     fireEvent.change(input, {
@@ -111,6 +124,7 @@ describe("Tests using XHR", () => {
     const searchResults = await waitFor(() =>
       container.querySelector("div.search-results")
     );
+    debug();
     // Length of children should be 2 including the "Fuzzy searching by URI" div
     expect(searchResults.children.length).toBe(2);
     expect(input.classList.contains("has-search-results")).toBe(true);
@@ -130,6 +144,9 @@ describe("Tests using XHR", () => {
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
+    await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
     fireEvent.change(input, {
       target: { value: "/docs/Web/HTML/Element/abbr" },
     });
@@ -145,6 +162,9 @@ describe("Tests using XHR", () => {
     const input = container.querySelector('[type="search"]');
     // Focus input to get titles from XHR
     fireEvent.focus(input);
+    await waitFor(() =>
+      container.querySelector('input[type="search"][placeholder^="Go ahead"]')
+    );
     fireEvent.change(input, {
       target: { value: "/docs/Web/HTML/Element/abbr" },
     });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,5 +1,4 @@
 import React from "react";
-// import { cleanup } from "@testing-library/react";
 
 // localStorage mock for tests
 const mockLocalStorage = () => {
@@ -32,8 +31,3 @@ beforeEach(() => {
     window.dispatchEvent(event);
   };
 });
-
-// afterEach(() => {
-//   // Unmounts React trees that were mounted with @testing-library/react's render.
-//   cleanup();
-// });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -20,14 +20,3 @@ const mockLocalStorage = () => {
 };
 
 global.localStorage = mockLocalStorage();
-
-beforeEach(() => {
-  // Replacing the native history.pushState with a wrapper to sniff calls to
-  // window.history.pushState
-  const nativeHistoryPushState = window.history.pushState;
-  window.history.pushState = function (state, title, url) {
-    nativeHistoryPushState.apply(this, arguments);
-    var event = new CustomEvent("pushState", { detail: { state, title, url } });
-    window.dispatchEvent(event);
-  };
-});

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import fs from "fs";
 import path from "path";
-import { ServerLocation } from "@reach/router";
+import { StaticRouter } from "react-router-dom/server";
 import sourceMapSupport from "source-map-support";
 
 import { App } from "../client/src/app";
@@ -143,9 +143,9 @@ export function buildHtmlAndJsonFromDoc({
 
   if (buildHtml) {
     rendered = render(
-      <ServerLocation url={uri}>
+      <StaticRouter location={uri} context={options}>
         <App {...options} />
-      </ServerLocation>,
+      </StaticRouter>,
       options
     );
   }

--- a/ssr/package.json
+++ b/ssr/package.json
@@ -9,12 +9,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@reach/router": "1.3.3",
     "cheerio": "1.0.0-rc.3",
     "dotenv": "8.2.0",
-    "react": "16.13.1",
     "prismjs": "1.20.0",
+    "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-router": "6.0.0-alpha.3",
+    "react-router-dom": "6.0.0-alpha.3",
     "source-map-support": "0.5.16"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,11 +2401,6 @@ arr-diff@^4.0.0:
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
-arr-flatten@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
-  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
-
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
@@ -2821,13 +2816,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
-
 bluebird@^3.4.7:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
@@ -2898,23 +2886,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.1, braces@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
-  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
-  dependencies:
-    arr-flatten "^1.1.0"
-    array-unique "^0.3.2"
-    extend-shallow "^2.0.1"
-    fill-range "^4.0.0"
-    isobject "^3.0.1"
-    repeat-element "^1.1.2"
-    snapdragon "^0.8.1"
-    snapdragon-node "^2.0.1"
-    split-string "^3.0.2"
-    to-regex "^3.0.1"
-
-braces@^3.0.1, braces@~3.0.2:
+braces@>=2.3.1, braces@^2.3.1, braces@^2.3.2, braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3339,6 +3311,11 @@ chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
+
+chownr@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -5138,7 +5115,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
@@ -5300,16 +5277,6 @@ filesize@6.0.1:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.0.1.tgz#f850b509909c7c86f7e450ea19006c31c2ed3d2f"
   integrity sha512-u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg==
 
-fill-range@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
-  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
-    to-regex-range "^2.1.0"
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -5448,7 +5415,7 @@ for-in@^0.1.3:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
   integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
 
-for-in@^1.0.1, for-in@^1.0.2:
+for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
@@ -5550,13 +5517,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.0.0.tgz#a6415edab02fae4b9e9230bc87ee2e4472003cd1"
@@ -5592,7 +5552,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-fstream@^1.0.0, fstream@^1.0.12:
+fstream@>=1.0.12, fstream@^1.0.0:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -5872,7 +5832,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.1.2:
+handlebars@>=4.5.3, handlebars@^4.1.2:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -6767,7 +6727,7 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -7386,7 +7346,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.1, js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@>=3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -7618,7 +7578,7 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2, kind-of@^3.0.3:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
@@ -7903,7 +7863,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@>=4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8258,14 +8218,6 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
@@ -8273,12 +8225,13 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+minizlib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.0.tgz#fd52c645301ef09a63a2c209697c294c6ce02cf3"
+  integrity sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
   dependencies:
-    minipass "^2.9.0"
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -8296,13 +8249,10 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
-  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
-  dependencies:
-    for-in "^1.0.2"
-    is-extendable "^1.0.1"
+mixin-deep@>=1.3.2, mixin-deep@^1.2.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-2.0.1.tgz#9a6946bef4a368401b784970ae3caaaa6bab02fa"
+  integrity sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA==
 
 mixin-object@^2.0.1:
   version "2.0.1"
@@ -8325,6 +8275,11 @@ mkdirp@0.5.1:
   integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -10903,16 +10858,6 @@ renderkid@^2.0.1:
     strip-ansi "^3.0.0"
     utila "^0.4.0"
 
-repeat-element@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
-  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
-
-repeat-string@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -11433,15 +11378,12 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^2.0.0, set-value@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+set-value@>=2.0.1, set-value@^2.0.0, set-value@^2.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
+  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
   dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
+    is-plain-object "^2.0.4"
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -11565,22 +11507,6 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
-
-snapdragon-node@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
-  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
-  dependencies:
-    define-property "^1.0.0"
-    isobject "^3.0.0"
-    snapdragon-util "^3.0.1"
-
-snapdragon-util@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
-  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
-  dependencies:
-    kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
   version "0.8.2"
@@ -11730,13 +11656,6 @@ spdy@^4.0.1:
     http-deceiver "^1.2.7"
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
-
-split-string@^3.0.1, split-string@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
-  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
-  dependencies:
-    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -12149,27 +12068,17 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
+tar@>=4.4.9, tar@^2.0.0, tar@^4:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.1.tgz#7b3bd6c313cb6e0153770108f8d70ac298607efa"
+  integrity sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==
   dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
-
-tar@^4:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
+    chownr "^1.1.3"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.0"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 term-size@^2.1.0:
   version "2.2.0"
@@ -12319,14 +12228,6 @@ to-readable-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
   integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
-
-to-regex-range@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
-  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
-  dependencies:
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -13389,11 +13290,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^3.0.2:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,7 +1096,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.9.2":
+"@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -1409,16 +1409,6 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
-
-"@reach/router@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.3.tgz#58162860dce6c9449d49be86b0561b5ef46d80db"
-  integrity sha512-gOIAiFhWdiVGSVjukKeNKkCRBLmnORoTPyBihI/jLunICPgxdP30DroAvPQuf1eVfQbfGJQDJkwhJXsNPMnVWw==
-  dependencies:
-    create-react-context "0.3.0"
-    invariant "^2.2.3"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2411,6 +2401,11 @@ arr-diff@^4.0.0:
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
   integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
@@ -2826,6 +2821,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
+  dependencies:
+    inherits "~2.0.0"
+
 bluebird@^3.4.7:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
@@ -2896,7 +2898,23 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@>=2.3.1, braces@^2.3.1, braces@^2.3.2, braces@^3.0.1, braces@~3.0.2:
+braces@^2.3.1, braces@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3321,11 +3339,6 @@ chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
-
-chownr@^1.1.3:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -3809,14 +3822,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-context@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
-  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
 
 cross-env@^7.0.2:
   version "7.0.2"
@@ -5133,7 +5138,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.2:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
@@ -5295,6 +5300,16 @@ filesize@6.0.1:
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.0.1.tgz#f850b509909c7c86f7e450ea19006c31c2ed3d2f"
   integrity sha512-u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg==
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -5433,7 +5448,7 @@ for-in@^0.1.3:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
   integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
@@ -5535,6 +5550,13 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
+
 fs-minipass@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.0.0.tgz#a6415edab02fae4b9e9230bc87ee2e4472003cd1"
@@ -5570,7 +5592,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-fstream@>=1.0.12, fstream@^1.0.0:
+fstream@^1.0.0, fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -5837,11 +5859,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 gzip-size@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -5855,7 +5872,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@>=4.5.3, handlebars@^4.1.2:
+handlebars@^4.1.2:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -5985,6 +6002,13 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+history@5.0.0-beta.4:
+  version "5.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0-beta.4.tgz#7fd3bb1f6c75d00d9b5112a816766bfc72d1a3cd"
+  integrity sha512-LMUnKPB5UlEzDF1BO0VxtDsrguGPO7SuQEmB/5OjL1305afR1O8FvX29rbJep4g2SLmKK3YdDA7+8ZDs8P8n8g==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6448,7 +6472,7 @@ interpret@1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6743,7 +6767,7 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -7362,7 +7386,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.1, js-yaml@>=3.13.1, js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -7594,7 +7618,7 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2, kind-of@^3.0.3:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
@@ -7879,7 +7903,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@>=4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8234,6 +8258,14 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
@@ -8241,13 +8273,12 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
-minizlib@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.0.tgz#fd52c645301ef09a63a2c209697c294c6ce02cf3"
-  integrity sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
+    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -8265,10 +8296,13 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@>=1.3.2, mixin-deep@^1.2.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-2.0.1.tgz#9a6946bef4a368401b784970ae3caaaa6bab02fa"
-  integrity sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA==
+mixin-deep@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
 
 mixin-object@^2.0.1:
   version "2.0.1"
@@ -8291,11 +8325,6 @@ mkdirp@0.5.1:
   integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -10262,7 +10291,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10515,10 +10544,21 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+react-router-dom@6.0.0-alpha.3:
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.0.0-alpha.3.tgz#295aa7691de913b81f481b7cb14418e3b2f08edf"
+  integrity sha512-3Fu9Az+ofgv58WxtaPokADdNXJmxE6td5na2HFIN0cgRBYo2TPJ83KlIt4XCNvq1Y473pr8hOkD621CmauztEw==
+  dependencies:
+    history "5.0.0-beta.4"
+    prop-types "^15.7.2"
+
+react-router@6.0.0-alpha.3:
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.0.0-alpha.3.tgz#c031a5262801315571f8b609620ae9c1b083dee3"
+  integrity sha512-Evp8ua5c7rFDIuF0KK/tkzbh7aPIWWyjWKr3yOLNine1liiphHZidDL/5jLTBjE9HN0/vdCZPuV2VWjZ82TShA==
+  dependencies:
+    history "5.0.0-beta.4"
+    prop-types "^15.7.2"
 
 react-scripts@3.4.1:
   version "3.4.1"
@@ -10862,6 +10902,16 @@ renderkid@^2.0.1:
     htmlparser2 "^3.3.0"
     strip-ansi "^3.0.0"
     utila "^0.4.0"
+
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 repeating@^2.0.0:
   version "2.0.1"
@@ -11383,12 +11433,15 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@>=2.0.1, set-value@^2.0.0, set-value@^2.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.2.tgz#74e8ecd023c33d0f77199d415409a40f21e61b90"
-  integrity sha512-npjkVoz+ank0zjlV9F47Fdbjfj/PfXyVhZvGALWsyIYU/qrMzpi6avjKW3/7KeSU2Df3I46BrN1xOI1+6vW0hA==
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
-    is-plain-object "^2.0.4"
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4:
   version "1.0.5"
@@ -11512,6 +11565,22 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
   version "0.8.2"
@@ -11661,6 +11730,13 @@ spdy@^4.0.1:
     http-deceiver "^1.2.7"
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -12073,17 +12149,27 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@>=4.4.9, tar@^2.0.0, tar@^4:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.1.tgz#7b3bd6c313cb6e0153770108f8d70ac298607efa"
-  integrity sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==
+tar@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
+  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
   dependencies:
-    chownr "^1.1.3"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.0"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
+    block-stream "*"
+    fstream "^1.0.12"
+    inherits "2"
+
+tar@^4:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
 
 term-size@^2.1.0:
   version "2.2.0"
@@ -12233,6 +12319,14 @@ to-readable-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
   integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -12727,13 +12821,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^1.6.0:
   version "1.6.0"
@@ -13302,6 +13389,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.0, yallist@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Fixes #357

`yarn workspace client build` ...

**before:**

```
File sizes after gzip:

  54.95 KB  build/static/js/2.b527d6f2.chunk.js
  10.59 KB  build/static/js/main.f7b85584.chunk.js
  5.05 KB   build/static/css/main.e800292a.chunk.css
  772 B     build/static/js/runtime-main.cea588d5.js
  532 B     build/static/css/2.3a14348e.chunk.css
```

**after:**

```
File sizes after gzip:

  53.69 KB  build/static/js/2.0189310b.chunk.js
  10.65 KB  build/static/js/main.35b80476.chunk.js
  5.05 KB   build/static/css/main.e800292a.chunk.css
  772 B     build/static/js/runtime-main.cea588d5.js
  532 B     build/static/css/2.3a14348e.chunk.css
```

So, a 1.5KB smaller? But it's not unexpected. As [mentioned in this comment](https://github.com/mdn/stumptown-renderer/issues/357#issuecomment-605731056), the huge bundle size diet is when you go from react-router v5 to v6. `@react/router` was already smaller which is understandable because I think much of the v6 API is based on the learnings of `@reach/router`. 

The code works but it's not yet clear exactly what the benefits are other than the meta-benefits of react-router being the project with more eyes on it unlike `@reach/router` which is in maintenance mode. I like some of the new hooks which feels much more right than props magically passed to components. 