### PR TITLE
use getByPlaceholderText to test search widget

### DIFF
--- a/client/src/search.test.js
+++ b/client/src/search.test.js
@@ -3,19 +3,8 @@ import { render, fireEvent, waitFor } from "@testing-library/react";
 import { SearchWidget } from "./search";
 
 it("renders without crashing", () => {
-  const { container } = render(<SearchWidget />);
-  expect(container).toBeDefined();
-});
-
-test("input placeholder changes when focused", async () => {
-  const { container } = render(<SearchWidget />);
-
-  const input = container.querySelector('[type="search"]');
-  fireEvent.focus(input);
-  expect(input.placeholder).toBe("Initializing search...");
-  await waitFor(() =>
-    container.querySelector('input[type="search"][placeholder^="Go ahead"]')
-  );
+  const { getByPlaceholderText } = render(<SearchWidget />);
+  expect(getByPlaceholderText(/Site search/)).toBeDefined();
 });
 
 describe("Tests using XHR", () => {
@@ -39,9 +28,17 @@ describe("Tests using XHR", () => {
     global.fetch.mockClear();
   });
 
+  test("input placeholder changes when focused", async () => {
+    const { getByPlaceholderText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
+    fireEvent.focus(input);
+    expect(getByPlaceholderText(/Initializing/));
+    await waitFor(() => getByPlaceholderText(/Go ahead/));
+  });
+
   test("XHR request on focusing input the first time", () => {
-    const { container } = render(<SearchWidget />);
-    const input = container.querySelector('[type="search"]');
+    const { getByPlaceholderText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
     // Fire initial focus event
     fireEvent.focus(input);
     // Expect XHR
@@ -54,60 +51,45 @@ describe("Tests using XHR", () => {
   });
 
   test("should set titles in localStorage", async () => {
-    const { container } = render(<SearchWidget />);
-    const input = container.querySelector('[type="search"]');
+    const { getByPlaceholderText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     expect(global.localStorage.getItem("titles")).toBeDefined();
   });
 
   test("should NOT get search results", async () => {
-    const { container, getByText } = render(<SearchWidget />);
-    const input = container.querySelector('[type="search"]');
+    const { getByPlaceholderText, getByText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "div" } });
     // Get the search results
-    const searchResults = await waitFor(() =>
-      container.querySelector("div.search-results")
-    );
-    expect(searchResults.children.length).toBe(1);
-    expect(input.classList.contains("has-search-results")).toBe(true);
-    expect(getByText("nothing found")).toBeDefined();
+    await waitFor(() => getByText("nothing found"));
   });
 
   test("should get search results", async () => {
-    const { container } = render(<SearchWidget />);
-    const input = container.querySelector('[type="search"]');
+    const { getByPlaceholderText, getByText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "ABb" } });
     // Get the search results
-    const searchResults = await waitFor(() =>
-      container.querySelector("div.search-results")
-    );
-    expect(searchResults.children.length).toBe(1);
-    expect(input.classList.contains("has-search-results")).toBe(true);
-    expect(container.textContent).toContain("The Abbreviation element");
+    // But can't use getByText on title because it's peppered with
+    // <mark> tags. But the small test with the path should be findable.
+    await waitFor(() => getByText(/Web \/ HTML \/ Element \/ abbr/));
   });
 
   test("should get search results by URI", async () => {
-    const { container, getByText } = render(<SearchWidget />);
-    const input = container.querySelector('[type="search"]');
+    const { getByText, getByPlaceholderText } = render(<SearchWidget />);
+    const input = getByPlaceholderText(/Site search/);
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     fireEvent.change(input, {
       target: { value: "/dwm/mtabr" },
     });
     // Get the search results
-    const searchResults = await waitFor(() =>
-      container.querySelector("div.search-results")
-    );
-    // Length of children should be 2 including the "Fuzzy searching by URI" div
-    expect(searchResults.children.length).toBe(2);
-    expect(input.classList.contains("has-search-results")).toBe(true);
-    expect(getByText("<abbr>: The Abbreviation element")).toBeDefined();
-    expect(getByText("Fuzzy searching by URI")).toBeDefined();
+    await waitFor(() => getByText(/Fuzzy searching by URI/));
   });
 
   test("should redirect when clicking a search result", async (done) => {
@@ -118,33 +100,20 @@ describe("Tests using XHR", () => {
       done();
     };
     window.addEventListener("pushState", onPushState);
-    const { container } = render(<SearchWidget pathname="/" />);
-    const input = container.querySelector('[type="search"]');
+    const { getByText, getByPlaceholderText } = render(
+      <SearchWidget pathname="/" />
+    );
+    const input = getByPlaceholderText(/Site search/);
     // Focus input to get titles from XHR
     fireEvent.focus(input);
     fireEvent.change(input, {
       target: { value: "/docs/Web/HTML/Element/abbr" },
     });
     // Get the search results
-    await waitFor(() => container.querySelector("div.search-results"));
-    const targetResult = container.querySelector("div.highlit");
+    const targetResult = await waitFor(() =>
+      getByText(/The Abbreviation element/)
+    );
     // Click the highlit result
     fireEvent.click(targetResult);
-  });
-
-  test("should remove search-results class after clicking a result", async () => {
-    const { container } = render(<SearchWidget pathname="/" />);
-    const input = container.querySelector('[type="search"]');
-    // Focus input to get titles from XHR
-    fireEvent.focus(input);
-    fireEvent.change(input, {
-      target: { value: "/docs/Web/HTML/Element/abbr" },
-    });
-    // Get the search results
-    await waitFor(() => container.querySelector("div.search-results"));
-    const targetResult = container.querySelector("div.highlit");
-    // Click the highlit result
-    fireEvent.click(targetResult);
-    expect(container.querySelector("div.search-results")).toBe(null);
   });
 });


### PR DESCRIPTION
Less `container` and more `getBy...` testing which is how Kent wanted it to be done. 