### PR TITLE
faster rendering by reading index.html once

### DIFF
--- a/ssr/package.json
+++ b/ssr/package.json
@@ -4,7 +4,7 @@
   "main": "dist/main.js",
   "license": "MPL-2.0",
   "scripts": {
-    "build": "webpack --config webpack.config.js --mode=development",
+    "build": "webpack --config webpack.config.js --mode=production",
     "build:watch": "webpack --config webpack.config.js --watch --mode=development",
     "test": "jest"
   },


### PR DESCRIPTION
The way we should distinguish between `production` and `development` in the React and the SSR code is that *all* SSR should be `production` and the only time it's `development` is when you use `yarn start` and open that `http://localhost:3000`. 

As of this change, any generated `client/build/$locale/**/*.html` is created with `process.env.NODE_ENV==='production'`. It actually doesn't make the build a whole lot faster. 
From **31.4 docs/s** to **33.8 docs/s**. But every little helps and the best of all is that the the generated `index.html` files should not have been made with anything that depended on `process.env.NODE_ENV==='development'`. 