### PR TITLE
Optimization in fixsyntaxhighlighting

### DIFF
--- a/ssr/syntax-highlighter.js
+++ b/ssr/syntax-highlighter.js
@@ -36,18 +36,17 @@ export function fixSyntaxHighlighting(document) {
   // that might have a syntax highlighting marker.
   document.body
     .filter((section) => {
-      // return (
-      //   section.type === "prose" &&
-      //   section.value &&
-      //   section.value.content &&
-      //   // This is an important piece of optimization. Very roughly
-      //   // only 1 in 5 prose sections has a <pre> tag in it. If it doesn't
-      //   // have one there's no point loading up `cheerio.load(...)`
-      //   // and doing selector lookups on it. So this is our
-      //   // chance to avoid bothering.
-      //   section.value.content.includes("</pre>")
-      // );
-      return section.type === "prose" && section.value && section.value.content;
+      return (
+        section.type === "prose" &&
+        section.value &&
+        section.value.content &&
+        // This is an optimization. Very roughly,
+        // only 1 in 5 prose sections has a <pre> tag in it. If it doesn't
+        // have one there's no point loading up `cheerio.load(...)`
+        // and doing selector lookups on it. So this is our
+        // chance to avoid bothering.
+        section.value.content.includes("</pre>")
+      );
     })
     .forEach((section) => {
       const $ = cheerio.load(section.value.content);


### PR DESCRIPTION
It's not a huge win but the `fixSyntaxHighlighting()` function is pretty important in terms of performance and I saw a low hanging fruit. 

Before (`master`): **31.4 docs/sec**
After (this branch): **33.1 docs/sec**

Also, the important difference was that `.filter()` which uses `section.value.content.includes("</pre>")` to quickly bail in (roughly) 4 out of 5 cases. 

The mess with `getPrismPluginName` was just to move it to module-level so I can use memoization for repeated calls. It's actually not used that much but will be when you use `stumptown-content`. I can take it out if you find it annoying. All I did was move it outside the `fixSyntaxHighlighting` and introduced a module-level `Map` which I use as memoization cache. 