### PR TITLE
ability to ignore cache invalidation of content/_all-titles.json

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -120,6 +120,11 @@ cli
     "don't reuse existing _all-titles.json",
     cli.BOOL
   )
+  .option(
+    "--ignore-titles-cache",
+    "reuse _all-titles.json if it exists independent of cache hashing",
+    cli.BOOL
+  )
   .option("--no-sitemaps", "don't generate all sitemap xml files", cli.BOOL)
   .option("--slugsearch <partofslug>", "filter by slug matches", cli.ARRAY, [])
   .option(

--- a/content/index.js
+++ b/content/index.js
@@ -121,7 +121,7 @@ cli
     cli.BOOL
   )
   .option(
-    "--ignore-titles-cache",
+    "--allow-stale-titles",
     "reuse _all-titles.json if it exists independent of cache hashing",
     cli.BOOL
   )

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -21,7 +21,12 @@ const {
   extractDocumentSections,
   extractSidebar,
 } = require("./document-extractor");
-const { ROOT_DIR, VALID_LOCALES, FLAWS_LEVELS } = require("./constants");
+const {
+  ROOT_DIR,
+  VALID_LOCALES,
+  FLAWS_LEVELS,
+  IGNORE_TITLES_CACHE,
+} = require("./constants");
 const { slugToFoldername } = require("./utils");
 
 const kumascript = require("kumascript");
@@ -267,6 +272,8 @@ class Builder {
 
     this.options.locales = cleanLocales(this.options.locales || []);
     this.options.notLocales = cleanLocales(this.options.notLocales || []);
+    this.options.ignoreTitlesCache =
+      this.options.ignoreTitlesCache || IGNORE_TITLES_CACHE;
 
     this.progressBar = !options.noProgressbar
       ? new ProgressBar({
@@ -597,11 +604,20 @@ class Builder {
         ).map(([key, value]) => [key.toLowerCase(), value])
       );
       // We got it from disk, but is it out-of-date?
-      if (this.allTitles.get("_hash") !== this.selfHash) {
+      const outOfDate = this.allTitles.get("_hash") !== this.selfHash;
+      if (outOfDate && !this.options.ignoreTitlesCache) {
         this.logger.info(
           chalk.yellow(`${allTitlesJsonFilepath} existed but is out-of-date.`)
         );
       } else {
+        if (outOfDate) {
+          this.logger.info(
+            chalk.yellow(
+              `Warning! ${allTitlesJsonFilepath} exists but is out-of-date. ` +
+                "To reset run `yarn clean`."
+            )
+          );
+        }
         // This means we DON'T need to re-generate all titles, so
         // let's set the context for the Kumascript renderer.
         this.macroRenderer.use(this.allTitles);

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -25,7 +25,7 @@ const {
   ROOT_DIR,
   VALID_LOCALES,
   FLAWS_LEVELS,
-  IGNORE_TITLES_CACHE,
+  ALLOW_STALE_TITLES,
 } = require("./constants");
 const { slugToFoldername } = require("./utils");
 
@@ -273,7 +273,7 @@ class Builder {
     this.options.locales = cleanLocales(this.options.locales || []);
     this.options.notLocales = cleanLocales(this.options.notLocales || []);
     this.options.ignoreTitlesCache =
-      this.options.ignoreTitlesCache || IGNORE_TITLES_CACHE;
+      this.options.ignoreTitlesCache || ALLOW_STALE_TITLES;
 
     this.progressBar = !options.noProgressbar
       ? new ProgressBar({

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -272,8 +272,8 @@ class Builder {
 
     this.options.locales = cleanLocales(this.options.locales || []);
     this.options.notLocales = cleanLocales(this.options.notLocales || []);
-    this.options.ignoreTitlesCache =
-      this.options.ignoreTitlesCache || ALLOW_STALE_TITLES;
+    this.options.allowStaleTitles =
+      this.options.allowStaleTitles || ALLOW_STALE_TITLES;
 
     this.progressBar = !options.noProgressbar
       ? new ProgressBar({
@@ -605,7 +605,7 @@ class Builder {
       );
       // We got it from disk, but is it out-of-date?
       const outOfDate = this.allTitles.get("_hash") !== this.selfHash;
-      if (outOfDate && !this.options.ignoreTitlesCache) {
+      if (outOfDate && !this.options.allowStaleTitles) {
         this.logger.info(
           chalk.yellow(`${allTitlesJsonFilepath} existed but is out-of-date.`)
         );

--- a/content/scripts/constants.js
+++ b/content/scripts/constants.js
@@ -105,6 +105,11 @@ const VALID_LOCALES = new Map(
   ].map((x) => [x.toLowerCase(), x])
 );
 
+const IGNORE_TITLES_CACHE = JSON.parse(
+  process.env.BUILD_IGNORE_TITLES_CACHE || "false"
+);
+assert(typeof IGNORE_TITLES_CACHE === "boolean");
+
 const FLAWS_LEVELS = Object.freeze({
   WARN: "warn",
   IGNORE: "ignore",
@@ -125,6 +130,7 @@ module.exports = {
   DEFAULT_BUILD_NOT_LOCALES,
   DEFAULT_SITEMAP_BASE_URL,
   DEFAULT_FOLDER_SEARCHES,
+  IGNORE_TITLES_CACHE,
   // DEFAULT_POPULARITIES_FILEPATH,
   // DEFAULT_STUMPTOWN_PACKAGED_ROOT,
   MAX_GOOGLE_ANALYTICS_URIS,

--- a/content/scripts/constants.js
+++ b/content/scripts/constants.js
@@ -105,10 +105,10 @@ const VALID_LOCALES = new Map(
   ].map((x) => [x.toLowerCase(), x])
 );
 
-const IGNORE_TITLES_CACHE = JSON.parse(
-  process.env.BUILD_IGNORE_TITLES_CACHE || "false"
+const ALLOW_STALE_TITLES = JSON.parse(
+  process.env.BUILD_ALLOW_STALE_TITLES || "false"
 );
-assert(typeof IGNORE_TITLES_CACHE === "boolean");
+assert(typeof ALLOW_STALE_TITLES === "boolean");
 
 const FLAWS_LEVELS = Object.freeze({
   WARN: "warn",
@@ -130,7 +130,7 @@ module.exports = {
   DEFAULT_BUILD_NOT_LOCALES,
   DEFAULT_SITEMAP_BASE_URL,
   DEFAULT_FOLDER_SEARCHES,
-  IGNORE_TITLES_CACHE,
+  ALLOW_STALE_TITLES,
   // DEFAULT_POPULARITIES_FILEPATH,
   // DEFAULT_STUMPTOWN_PACKAGED_ROOT,
   MAX_GOOGLE_ANALYTICS_URIS,

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -13,7 +13,7 @@ CLI arguments. And
 The general rule is that environment variables specific to the builder are
 all prefixed with `BUILD_`. E.g. `BUILD_LOCALES`
 
-### `BUILD_IGNORE_TITLES_CACHE`
+### `BUILD_ALLOW_STALE_TITLES`
 
 **Default: `false`**
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -1,0 +1,29 @@
+# Environment Variables
+
+Most things can be controlled via environment variables. Some things are
+specific to the client and some are specific to the builder etc.
+
+This document attempts to describe each environment variable.
+
+## Builder
+
+For the builder, a lot of environment variables can be overridden with
+CLI arguments. And
+
+The general rule is that environment variables specific to the builder are
+all prefixed with `BUILD_`. E.g. `BUILD_LOCALES`
+
+### `BUILD_IGNORE_TITLES_CACHE`
+
+**Default: `false`**
+
+When you build, it needs to first generate a complete map of all documents
+with their URI as the keys. That map gets cached to disk as
+`content/_all-titles.json` and within there's a `hash` key which tells
+what digest of the code that it was built with. If the code (or
+things like `package.json` or `yarn.lock`) changes, this invalidates
+the stored file.
+Generating this can be time-consuming if you're doing rapid development.
+
+Setting this environment variable to `true` means it simply cares if
+the file exists or not independent of the hash digest.


### PR DESCRIPTION
Fixes #562

Ahhh That's much better. Now I can run `node content build ...` over and over between small changes without having to wait for the `_all-titles.json` to be regenerated every time. 
Caching is hard but maybe we should have a worker that starts when the file is out of date and goes and fixes it in the background. But that would be vastly overcomplicated and never foolproof. 

Note that I started a new file called `docs/envvars.md` which only has this new one. If/when you merge this I'll promise to make a follow-up to describe all the other interesting and important env vars. 
By the way, our README is vastly out of date because it's very stumptown'y. 