### PR TITLE
ignore more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ content/build/
 content/_all-titles.json
 ci-content/
 kumascript/coverage/
+kumascript/node_modules/
 
 # Can be removed once content lives in its own repo
 archivecontent/files


### PR DESCRIPTION
As of [the `ejs` upgrade](https://github.com/mdn/stumptown-renderer/pull/551) it now creates a executable inside the `kumascript` workspace. 

Without this, you get a new file after a fresh `yarn install`